### PR TITLE
Added tests on QnA scenarios for hSD01

### DIFF
--- a/app/gameengine.py
+++ b/app/gameengine.py
@@ -3416,7 +3416,9 @@ class GameEngine:
                         available_targets = [holomem for holomem in available_targets if any(tag in holomem["tags"] for tag in to_limitation_tags)]
                 available_targets = ids_from_cards(available_targets)
                 cheer_on_each_mem = effect_player.get_cheer_on_each_holomem()
-                if len(available_targets) > 1:
+
+                # there should be valid targets and sources for cheers to be moved
+                if len(available_targets) > 1 and len(available_cheer) > 0:
                     decision_event = {
                         "event_type": EventType.EventType_Decision_SendCheer,
                         "desired_response": GameAction.EffectResolution_MoveCheerBetweenHolomems,

--- a/tests/hSD01/test_hsd01_001.py
+++ b/tests/hSD01/test_hsd01_001.py
@@ -1,0 +1,124 @@
+import unittest
+
+from app.gameengine import GameEngine, GameAction
+from app.gameengine import PlayerState
+from app.gameengine import EventType
+from tests.helpers import *
+
+
+class Test_hSD01_001(unittest.TestCase):
+  engine: GameEngine
+  player1: str
+  player2: str
+
+  def setUp(self):
+    p1_deck = generate_deck_with("hSD01-001") # Sora Oshi
+    initialize_game_to_third_turn(self, p1_deck)
+
+
+  def test_hsd01_001_replacement_with_no_cheers_on_stage(self):
+    # QnA: Q1 (2024.09.21)
+    engine = self.engine
+
+    p1: PlayerState = engine.get_player(self.player1)
+    
+    """Test"""
+    self.assertEqual(engine.active_player_id, self.player1)
+    p1.generate_holopower(1)
+    p1.archive_attached_cards(p1.get_cheer_ids_on_holomems())
+
+    # Events    
+    events = engine.grab_events()
+    validate_consecutive_events(self, self.player1, events, [
+      (EventType.EventType_GenerateHolopower, { "generating_player_id": self.player1 }),
+      (EventType.EventType_MoveAttachedCard, {}),
+      (EventType.EventType_MoveAttachedCard, {})
+    ])
+
+    reset_mainstep(self)
+    engine.handle_game_message(self.player1, GameAction.MainStepOshiSkill, { "skill_id": "replacement" })
+
+    # Events
+    events = engine.grab_events()
+    validate_consecutive_events(self, self.player1, events, [
+      (EventType.EventType_MoveCard, { "from_zone": "holopower", "to_zone": "archive" }),
+      (EventType.EventType_OshiSkillActivation, {}),
+      (EventType.EventType_Decision_MainStep, {})
+    ])
+
+
+  def test_hSD01_001_soyouretheenemy_can_target_resting_holomem(self):
+    # QnA: Q203 (2024.10.04)
+    engine = self.engine
+
+    p1: PlayerState = engine.get_player(self.player1)
+    p2: PlayerState = engine.get_player(self.player2)
+    
+    # Setup for p2 to use soyouretheenemy on p1's resting holomem
+    target_card_id = "player1_2"
+    do_collab_get_events(self, p1, target_card_id)
+    end_turn(self) # p1 end turn
+    
+    do_cheer_step_on_card(self, p2.center[0])
+    end_turn(self) # p2 end turn
+
+    do_cheer_step_on_card(self, p1.center[0])
+    reset_mainstep(self)
+
+    self.assertEqual(p1.backstage[-1]["game_card_id"], target_card_id)
+    self.assertTrue(p1.backstage[-1]["resting"])
+    end_turn(self) # p1 end turn
+    
+
+    """Test"""
+    self.assertEqual(engine.active_player_id, self.player2)
+    p2.generate_holopower(2)
+
+    do_cheer_step_on_card(self, p2.center[0])
+    reset_mainstep(self)    
+    engine.handle_game_message(self.player2, GameAction.MainStepOshiSkill, { "skill_id": "soyouretheenemy" })
+
+    # Events
+    events = engine.grab_events()
+    validate_consecutive_events(self, self.player2, events, [
+      (EventType.EventType_MoveCard, { "from_zone": "holopower", "to_zone": "archive" }),
+      (EventType.EventType_MoveCard, { "from_zone": "holopower", "to_zone": "archive" }),
+      (EventType.EventType_OshiSkillActivation, {}),
+      (EventType.EventType_Decision_SwapHolomemToCenter, {})
+    ])
+
+    # check that target_card_id is in the choices
+    self.assertEqual(events[-1]["event_player_id"], self.player2)
+    self.assertIn(target_card_id, events[-1]["cards_can_choose"])
+    
+    
+  def test_hSD01_001_resolve_as_much_as_possible_for_soyouretheenemy(self):
+    # QnA: Q204 (2024.10.04)
+    # First part can fizzle out (swap holomem). But the +damage still applies.
+    engine = self.engine
+
+    p1: PlayerState = engine.get_player(self.player1)
+    p2: PlayerState = engine.get_player(self.player2)
+
+    # Setup for p2 to use soyouretheenemy on an empty backstage
+    p1.backstage = []
+    end_turn(self) # p1 end turn
+
+    
+    """Test"""
+    self.assertEqual(engine.active_player_id, self.player2)
+    do_cheer_step_on_card(self, p2.center[0])
+    p2.generate_holopower(2)
+
+    reset_mainstep(self)
+    engine.handle_game_message(self.player2, GameAction.MainStepOshiSkill, { "skill_id": "soyouretheenemy" })
+
+    # Events
+    events = engine.grab_events()
+    validate_consecutive_events(self, self.player2, events, [
+      (EventType.EventType_MoveCard, { "from_zone": "holopower", "to_zone": "archive" }),
+      (EventType.EventType_MoveCard, { "from_zone": "holopower", "to_zone": "archive" }),
+      (EventType.EventType_OshiSkillActivation, {}),
+      (EventType.EventType_AddTurnEffect, {}),
+      (EventType.EventType_Decision_MainStep, {})
+    ])

--- a/tests/hSD01/test_hsd01_002.py
+++ b/tests/hSD01/test_hsd01_002.py
@@ -5,10 +5,6 @@ from app.gameengine import PlayerState
 from app.gameengine import EventType
 from tests.helpers import *
 
-import json
-def jsonprint(data):
-  print(json.dumps(data, indent=4))
-
 class Test_hSD01_002(unittest.TestCase):
   engine: GameEngine
   player1: str

--- a/tests/hSD01/test_hsd01_002.py
+++ b/tests/hSD01/test_hsd01_002.py
@@ -1,0 +1,71 @@
+import unittest
+
+from app.gameengine import GameEngine, GameAction
+from app.gameengine import PlayerState
+from app.gameengine import EventType
+from tests.helpers import *
+
+import json
+def jsonprint(data):
+  print(json.dumps(data, indent=4))
+
+class Test_hSD01_002(unittest.TestCase):
+  engine: GameEngine
+  player1: str
+
+  def setUp(self):
+    initialize_game_to_third_turn(self)
+  
+
+  def test_hSD01_002_micintherighthand_with_no_cheer_on_stage(self):
+    # QnA: Q2 (2024.09.21)
+    # weird question since this oshi skill targets the archive, not the stage.
+    engine = self.engine
+
+    p1: PlayerState = engine.get_player(self.player1)
+
+
+    """Test"""
+    self.assertEqual(engine.active_player_id, self.player1)
+    p1.generate_holopower(3)
+    p1.center[0]["attached_cheer"] = [] # empty out cheers on stage
+    self.assertEqual(len(p1.get_cheer_ids_on_holomems()), 0)
+
+    reset_mainstep(self)
+    engine.handle_game_message(self.player1, GameAction.MainStepOshiSkill, { "skill_id": "micintherighthand" })
+
+    # Events
+    events = engine.grab_events()
+    validate_consecutive_events(self, self.player1, events, [
+      (EventType.EventType_MoveCard, { "from_zone": "holopower", "to_zone": "archive" }),
+      (EventType.EventType_MoveCard, { "from_zone": "holopower", "to_zone": "archive" }),
+      (EventType.EventType_MoveCard, { "from_zone": "holopower", "to_zone": "archive" }),
+      (EventType.EventType_OshiSkillActivation, {}),
+      (EventType.EventType_Decision_MainStep, {})
+    ])
+
+
+  def test_hSD01_002_micintherighthand_with_no_cheer_on_archive(self):
+    # QnA: Q2 (2024.09.21)
+    engine = self.engine
+
+    p1: PlayerState = engine.get_player(self.player1)
+
+
+    """Test"""
+    self.assertEqual(engine.active_player_id, self.player1)
+    p1.generate_holopower(3)
+    self.assertEqual(len(p1.archive), 0)
+
+    reset_mainstep(self)
+    engine.handle_game_message(self.player1, GameAction.MainStepOshiSkill, { "skill_id": "micintherighthand" })
+
+    # Events
+    events = engine.grab_events()
+    validate_consecutive_events(self, self.player1, events, [
+      (EventType.EventType_MoveCard, { "from_zone": "holopower", "to_zone": "archive" }),
+      (EventType.EventType_MoveCard, { "from_zone": "holopower", "to_zone": "archive" }),
+      (EventType.EventType_MoveCard, { "from_zone": "holopower", "to_zone": "archive" }),
+      (EventType.EventType_OshiSkillActivation, {}),
+      (EventType.EventType_Decision_MainStep, {})
+    ])

--- a/tests/hSD01/test_hsd01_004.py
+++ b/tests/hSD01/test_hsd01_004.py
@@ -1,0 +1,183 @@
+import unittest
+
+from app.gameengine import GameEngine, GameAction
+from app.gameengine import PlayerState
+from app.gameengine import EventType
+from tests.helpers import *
+
+
+class Test_hSD01_004(unittest.TestCase):
+  engine: GameEngine
+  player1: str
+  player2: str
+
+  
+  def test_hSD01_004_collab_effect_does_not_apply_to_arts_advantage_damage(self):
+    # QnA: Q3 (2024.09.21)
+    
+    # Setup to put a holomem with color advantage against p2 center
+    p1_deck = generate_deck_with("", { "hBP01-047": 1 })
+    initialize_game_to_third_turn(self, p1_deck)
+    engine = self.engine
+
+    p1: PlayerState = engine.get_player(self.player1)
+    p2: PlayerState = engine.get_player(self.player2)
+
+    p1.center = []
+    center_card = put_card_in_play(self, p1, "hBP01-047", p1.center)
+    spawn_cheer_on_card(self, p1, center_card["game_card_id"], "green", "g1")
+    spawn_cheer_on_card(self, p1, center_card["game_card_id"], "green", "g2")
+    spawn_cheer_on_card(self, p1, center_card["game_card_id"], "green", "g3")
+    spawn_cheer_on_card(self, p1, center_card["game_card_id"], "white", "w1")
+    
+    downed_holomem = p2.center[0] # holomem to be downed after the attack
+        
+
+    """Test"""
+    self.assertEqual(engine.active_player_id, self.player1)
+    collab_card_id = "player1_5"
+
+    # Events
+    events = do_collab_get_events(self, p1, collab_card_id)
+    self.assertEqual(len(p1.collab), 1)
+    validate_consecutive_events(self, self.player1, events, [
+      (EventType.EventType_Collab, { "collab_card_id": collab_card_id }),
+      (EventType.EventType_AddTurnEffect, {}),
+      (EventType.EventType_Decision_MainStep, {})
+    ])
+
+    begin_performance(self)
+    engine.handle_game_message(self.player1, GameAction.PerformanceStepUseArt, {
+      "art_id": "anewmap",
+      "performer_id": p1.center[0]["game_card_id"],
+      "target_id": p2.center[0]["game_card_id"]
+    })
+
+    # Events
+    collab_boost = 20
+    center_art = 120
+    color_advantage = 50
+
+    events = engine.grab_events()
+    validate_consecutive_events(self, self.player1, events, [
+      (EventType.EventType_PerformArt, { "active_player": self.player1, "power": center_art }),
+      (EventType.EventType_BoostStat, { "amount": collab_boost, "source_card_id": collab_card_id }),
+      (EventType.EventType_BoostStat, { "amount": color_advantage, "source_card_id": p1.center[0]["game_card_id"] }),
+      (EventType.EventType_DamageDealt, { "damage": collab_boost + center_art + color_advantage }), # no additional damage for color adv.
+      (EventType.EventType_DownedHolomem_Before, {}),
+      (EventType.EventType_DownedHolomem, { "target_id": downed_holomem["game_card_id"] }),
+      (EventType.EventType_Decision_SendCheer, {})
+    ])
+
+  def test_hSD01_004_collab_effect_does_not_apply_to_arts_additional_damage(self):
+    # QnA: Q3 (2024.09.21)
+
+    # Setup to put a holomem with additional arts damage
+    p1_deck = generate_deck_with("", { "hBP01-062": 1 })
+    initialize_game_to_third_turn(self, p1_deck)
+    engine = self.engine
+
+    p1: PlayerState = engine.get_player(self.player1)
+    p2: PlayerState = engine.get_player(self.player2)
+
+    p1.center = []
+    center_card = put_card_in_play(self, p1, "hBP01-062", p1.center)
+    spawn_cheer_on_card(self, p1, center_card["game_card_id"], "red", "r1")
+
+    downed_holomem = p2.center[0] # holomem to be downed after the attack
+
+    """Test"""
+    self.assertEqual(engine.active_player_id, self.player1)
+    collab_card_id = "player1_5"
+
+    events = do_collab_get_events(self, p1, collab_card_id)
+    self.assertEqual(len(p1.collab), 1)
+    validate_consecutive_events(self, self.player1, events, [
+      (EventType.EventType_Collab, { "collab_card_id": collab_card_id }),
+      (EventType.EventType_AddTurnEffect, {}),
+      (EventType.EventType_Decision_MainStep, {})
+    ])
+
+    begin_performance(self)
+    engine.handle_game_message(self.player1, GameAction.PerformanceStepUseArt, {
+      "art_id": "kikkeriki",
+      "performer_id": p1.center[0]["game_card_id"],
+      "target_id": p2.center[0]["game_card_id"]
+    })
+
+    # Events
+    collab_boost = 20
+    center_art = 20
+
+    events = engine.grab_events()
+    validate_consecutive_events(self, self.player1, events, [
+      (EventType.EventType_PerformArt, { "active_player": self.player1, "power": center_art }),
+      (EventType.EventType_BoostStat, { "amount": collab_boost, "source_card_id": collab_card_id }),
+      (EventType.EventType_Decision_Choice, {}) # choose to activate kiara art boost
+    ])
+
+    engine.handle_game_message(self.player1, GameAction.EffectResolution_MakeChoice, { "choice_index": 0 })
+    engine.handle_game_message(self.player1, GameAction.EffectResolution_ChooseCardsForEffect, { "card_ids": [p1.hand[0]["game_card_id"]] })
+
+    # Events
+    art_boost = 20
+
+    events = engine.grab_events()
+    validate_consecutive_events(self, self.player1, events, [
+      (EventType.EventType_Decision_ChooseCards, { "from_zone": "hand" }),
+      (EventType.EventType_MoveCard, { "from_zone": "hand", "to_zone": "archive" }),
+      (EventType.EventType_BoostStat, { "amount": art_boost, "source_card_id": p1.center[0]["game_card_id"] }),
+      (EventType.EventType_DamageDealt, { "damage": collab_boost + center_art + art_boost }),
+      (EventType.EventType_DownedHolomem_Before, {}),
+      (EventType.EventType_DownedHolomem, { "target_id": downed_holomem["game_card_id"] }),
+      (EventType.EventType_Decision_SendCheer, {})
+    ])
+
+  def test_hsd01_004_collab_boost_still_applies_after_bloom(self):
+    # QnA: Q208 (2024.10.04)
+    initialize_game_to_third_turn(self)
+    engine = self.engine
+
+    p1: PlayerState = engine.get_player(self.player1)
+    p2: PlayerState = engine.get_player(self.player2)
+
+
+    """Test"""
+    self.assertEqual(engine.active_player_id, self.player1)
+    collab_card_id = "player1_5" # hSD01-004
+    bloom_card_id = "player1_9" # hSD01-005
+
+    # Events
+    events = do_collab_get_events(self, p1, collab_card_id)
+    self.assertEqual(len(p1.collab), 1)
+    validate_consecutive_events(self, self.player1, events, [
+      (EventType.EventType_Collab, { "collab_card_id": collab_card_id }),
+      (EventType.EventType_AddTurnEffect, {}),
+      (EventType.EventType_Decision_MainStep, {})
+    ])
+
+    do_bloom(self, p1, bloom_card_id, p1.center[0]["game_card_id"])
+
+    begin_performance(self)
+    engine.handle_game_message(self.player1, GameAction.PerformanceStepUseArt, { 
+      "art_id": "nunnunshiyo",
+      "performer_id": p1.center[0]["game_card_id"],
+      "target_id": p2.center[0]["game_card_id"]
+    })
+
+    # Events
+    collab_boost = 20
+    center_art = 30
+
+    events = engine.grab_events()
+    validate_consecutive_events(self, self.player1, events, [
+      (EventType.EventType_PerformArt, { "active_player": self.player1, "power": center_art }),
+      (EventType.EventType_BoostStat, { "amount": collab_boost, "source_card_id": collab_card_id }),
+      (EventType.EventType_DamageDealt, { "damage": collab_boost + center_art }), # boost still applies
+      (EventType.EventType_EndTurn, {}),
+      (EventType.EventType_TurnStart, { "active_player": self.player2 }),
+      (EventType.EventType_ResetStepActivate, {}),
+      (EventType.EventType_ResetStepCollab, {}),
+      (EventType.EventType_Draw, {}),
+      (EventType.EventType_CheerStep, {})
+    ])

--- a/tests/hSD01/test_hsd01_006.py
+++ b/tests/hSD01/test_hsd01_006.py
@@ -1,0 +1,162 @@
+import unittest
+
+from app.gameengine import GameEngine, GameAction
+from app.gameengine import PlayerState
+from app.gameengine import EventType
+from tests.helpers import *
+
+
+class Test_hSD01_006(unittest.TestCase):
+  engine: GameEngine
+  player1: str
+  player2: str
+
+  def setUp(self):
+    initialize_game_to_third_turn(self)
+
+  def test_hSD01_006_sorazsympathy_works_with_soraz(self):
+    # QnA: Q4 (2024.09.21)
+    # QnA: Q5 (2024.09.21)
+
+    # Setup to put sora 1st buzz to center with soraz
+    engine = self.engine
+
+    p1: PlayerState = engine.get_player(self.player1)
+    p2: PlayerState = engine.get_player(self.player2)
+
+    p1.center = []
+    center_card = put_card_in_play(self, p1, "hSD01-006", p1.center)
+    spawn_cheer_on_card(self, p1, center_card["game_card_id"], "white", "w1")
+    spawn_cheer_on_card(self, p1, center_card["game_card_id"], "green", "g1")
+    spawn_cheer_on_card(self, p1, center_card["game_card_id"], "green", "g2")
+
+    p1.backstage = []
+    collab_card = put_card_in_play(self, p1, "hSD01-013", p1.backstage)
+
+    downed_holomem = p2.center[0] # holomem to be downed after the attack
+
+    """Test"""
+    self.assertEqual(engine.active_player_id, self.player1)
+
+    # Events
+    events = do_collab_get_events(self, p1, collab_card["game_card_id"])
+    validate_consecutive_events(self, self.player1, events, [
+      (EventType.EventType_Collab, { "collab_card_id": collab_card["game_card_id"] }),
+      (EventType.EventType_Decision_MainStep, {})
+    ])
+
+    begin_performance(self)
+    engine.handle_game_message(self.player1, GameAction.PerformanceStepUseArt, {
+      "art_id": "sorazsympathy",
+      "performer_id": p1.center[0]["game_card_id"],
+      "target_id": p2.center[0]["game_card_id"]
+    })
+
+    # Events
+    center_art = 60
+    art_boost = 50
+
+    events = engine.grab_events()
+    validate_consecutive_events(self, self.player1, events, [
+      (EventType.EventType_PerformArt, { "active_player": self.player1, "power": center_art }),
+      (EventType.EventType_BoostStat, { "amount": art_boost, "source_card_id": p1.center[0]["game_card_id"] }),
+      (EventType.EventType_DamageDealt, { "damage": center_art + art_boost }), # damage boost applies
+      (EventType.EventType_DownedHolomem_Before, {}),
+      (EventType.EventType_DownedHolomem, { "target_id": downed_holomem["game_card_id"] }),
+      (EventType.EventType_Decision_SendCheer, {})
+    ])
+
+  
+  def test_hSD01_006_sorazsympathy_works_with_azki_cards(self):
+    # Setup to put sora 1st buzz to center with an azki card
+    engine = self.engine
+
+    p1: PlayerState = engine.get_player(self.player1)
+    p2: PlayerState = engine.get_player(self.player2)
+
+    p1.center = []
+    center_card = put_card_in_play(self, p1, "hSD01-006", p1.center)
+    spawn_cheer_on_card(self, p1, center_card["game_card_id"], "white", "w1")
+    spawn_cheer_on_card(self, p1, center_card["game_card_id"], "green", "g1")
+    spawn_cheer_on_card(self, p1, center_card["game_card_id"], "green", "g2")
+
+    p1.backstage = []
+    collab_card = put_card_in_play(self, p1, "hSD01-008", p1.backstage)
+
+    downed_holomem = p2.center[0] # holomem to be downed after the attack
+
+    """Test"""
+    self.assertEqual(engine.active_player_id, self.player1)
+
+    # Events
+    events = do_collab_get_events(self, p1, collab_card["game_card_id"])
+    validate_consecutive_events(self, self.player1, events, [
+      (EventType.EventType_Collab, { "collab_card_id": collab_card["game_card_id"] }),
+      (EventType.EventType_Decision_MainStep, {})
+    ])
+
+    begin_performance(self)
+    engine.handle_game_message(self.player1, GameAction.PerformanceStepUseArt, {
+      "art_id": "sorazsympathy",
+      "performer_id": p1.center[0]["game_card_id"],
+      "target_id": p2.center[0]["game_card_id"]
+    })
+
+    # Events
+    center_art = 60
+    art_boost = 50
+
+    events = engine.grab_events()
+    validate_consecutive_events(self, self.player1, events, [
+      (EventType.EventType_PerformArt, { "active_player": self.player1, "power": center_art }),
+      (EventType.EventType_BoostStat, { "amount": art_boost, "source_card_id": p1.center[0]["game_card_id"] }),
+      (EventType.EventType_DamageDealt, { "damage": center_art + art_boost }), # damage boost applies
+      (EventType.EventType_DownedHolomem_Before, {}),
+      (EventType.EventType_DownedHolomem, { "target_id": downed_holomem["game_card_id"] }),
+      (EventType.EventType_Decision_SendCheer, {})
+    ])
+
+  def test_hSD01_006_sorazsympathy_does_not_work_with_other_names(self):
+    # Setup to put sora 1st buzz to center
+    engine = self.engine
+
+    p1: PlayerState = engine.get_player(self.player1)
+    p2: PlayerState = engine.get_player(self.player2)
+
+    p1.center = []
+    center_card = put_card_in_play(self, p1, "hSD01-006", p1.center)
+    spawn_cheer_on_card(self, p1, center_card["game_card_id"], "white", "w1")
+    spawn_cheer_on_card(self, p1, center_card["game_card_id"], "green", "g1")
+    spawn_cheer_on_card(self, p1, center_card["game_card_id"], "green", "g2")
+
+    downed_holomem = p2.center[0] # holomem to be downed after the attack
+
+    """Test"""
+    self.assertEqual(engine.active_player_id, self.player1)
+    collab_card = p1.backstage[0]
+
+    # Events
+    events = do_collab_get_events(self, p1, collab_card["game_card_id"])
+    validate_consecutive_events(self, self.player1, events, [
+      (EventType.EventType_Collab, { "collab_card_id": collab_card["game_card_id"] }),
+      (EventType.EventType_Decision_MainStep, {})
+    ])
+
+    begin_performance(self)
+    engine.handle_game_message(self.player1, GameAction.PerformanceStepUseArt, {
+      "art_id": "sorazsympathy",
+      "performer_id": p1.center[0]["game_card_id"],
+      "target_id": p2.center[0]["game_card_id"]
+    })
+
+    # Events
+    center_art = 60
+
+    events = engine.grab_events()
+    validate_consecutive_events(self, self.player1, events, [
+      (EventType.EventType_PerformArt, { "active_player": self.player1, "power": center_art }),
+      (EventType.EventType_DamageDealt, { "damage": center_art }), # no damage boost
+      (EventType.EventType_DownedHolomem_Before, {}),
+      (EventType.EventType_DownedHolomem, { "target_id": downed_holomem["game_card_id"] }),
+      (EventType.EventType_Decision_SendCheer, {})
+    ])

--- a/tests/hSD01/test_hsd01_007.py
+++ b/tests/hSD01/test_hsd01_007.py
@@ -1,0 +1,61 @@
+import unittest
+
+from app.gameengine import GameEngine, GameAction
+from app.gameengine import PlayerState
+from app.gameengine import EventType
+from tests.helpers import *
+
+import json
+def jsonimport(data):
+  print(json.dumps(data, indent=4))
+
+
+class Test_hSD01_007(unittest.TestCase):
+  engine: GameEngine
+  player1: str
+
+  def setUp(self):
+    initialize_game_to_third_turn(self)
+
+
+  def test_hSD01_007_collab_effect_can_return_the_same_card(self):
+    # QnA: Q6 (2024.09.21)
+
+    engine = self.engine
+
+    p1: PlayerState = engine.get_player(self.player1)
+
+    p1.backstage = []
+    collab_card = put_card_in_play(self, p1, "hSD01-007", p1.backstage)
+
+    # Events
+    events = do_collab_get_events(self, p1, collab_card["game_card_id"])
+    validate_consecutive_events(self, self.player1, events, [
+      (EventType.EventType_Collab, { "collab_card_id": collab_card["game_card_id"] }),
+      (EventType.EventType_Decision_ChooseCards, { "from_zone": "holopower" })
+    ])
+
+
+    """Test"""
+    self.assertEqual(engine.active_player_id, self.player1)
+    moved_card_id = p1.holopower[0]["game_card_id"]
+
+    engine.handle_game_message(self.player1, GameAction.EffectResolution_ChooseCardsForEffect, { "card_ids": [moved_card_id] })
+
+    # Events
+    events = engine.grab_events()
+    validate_consecutive_events(self, self.player1, events, [
+      (EventType.EventType_MoveCard, { "from_zone": "holopower", "to_zone": "hand" }),
+      (EventType.EventType_Decision_ChooseCards, { "from_zone": "hand" })
+    ])
+
+    engine.handle_game_message(self.player1, GameAction.EffectResolution_ChooseCardsForEffect, { "card_ids": [moved_card_id] })
+
+    # Events
+    events = engine.grab_events()
+    validate_consecutive_events(self, self.player1, events, [
+      (EventType.EventType_MoveCard, { "from_zone": "hand", "to_zone": "holopower" }),
+      (EventType.EventType_Decision_MainStep, {})
+    ])
+    self.assertEqual(len(p1.holopower), 1)
+    self.assertAlmostEqual(p1.holopower[0]["game_card_id"], moved_card_id) # card returned to the same place

--- a/tests/hSD01/test_hsd01_009.py
+++ b/tests/hSD01/test_hsd01_009.py
@@ -1,0 +1,178 @@
+import unittest
+
+from app.gameengine import GameEngine, GameAction
+from app.gameengine import PlayerState
+from app.gameengine import EventType
+from tests.helpers import *
+
+import json
+def jsonprint(data):
+  print(json.dumps(data, indent=4))
+
+class Test_hSD01_009(unittest.TestCase):
+  engine: GameEngine
+  player1: str
+    
+  
+  def setUp(self):
+    initialize_game_to_third_turn(self)
+  
+
+  def test_hSD01_009_collab_effect_works_even_with_empty_cheer_deck(self):
+    # QnA: Q7 (2024.09.21)
+    
+    engine = self.engine
+
+    p1: PlayerState = engine.get_player(self.player1)
+
+    p1.backstage = p1.backstage[1:5]
+    collab_card = put_card_in_play(self, p1, "hSD01-009", p1.backstage)
+
+    p1.cheer_deck = [] # empty cheer deck
+
+    # Events
+    events = do_collab_get_events(self, p1, collab_card["game_card_id"])
+    validate_consecutive_events(self, self.player1, events, [
+      (EventType.EventType_Collab, { "collab_card_id": collab_card["game_card_id"] }),
+      (EventType.EventType_Decision_Choice, {})
+    ])
+
+
+    """Test"""
+    self.assertEqual(engine.active_player_id, self.player1)
+
+    engine.handle_game_message(self.player1, GameAction.EffectResolution_MakeChoice, { "choice_index": 0 })
+
+    # Events
+    events = engine.grab_events()
+    validate_consecutive_events(self, self.player1, events, [
+      (EventType.EventType_RollDie, { "die_result": 1, "rigged": False }),
+      (EventType.EventType_Choice_SendCollabBack, {})
+    ]) # events skipped moving cheer from cheer deck
+
+    engine.handle_game_message(self.player1, GameAction.EffectResolution_MakeChoice, { "choice_index": 0 })
+
+    # Events
+    events = engine.grab_events()
+    validate_consecutive_events(self, self.player1, events, [
+      (EventType.EventType_Decision_MainStep, {})
+    ])
+
+  def test_hSD01_009_collab_effect_moves_cheer_from_cheer_deck(self):
+    engine = self.engine
+
+    p1: PlayerState = engine.get_player(self.player1)
+
+    p1.backstage = p1.backstage[1:5]
+    collab_card = put_card_in_play(self, p1, "hSD01-009", p1.backstage)
+
+    # Events
+    events = do_collab_get_events(self, p1, collab_card["game_card_id"])
+    validate_consecutive_events(self, self.player1, events, [
+      (EventType.EventType_Collab, { "collab_card_id": collab_card["game_card_id"] }),
+      (EventType.EventType_Decision_Choice, {})
+    ])
+
+
+    """Test"""
+    self.assertEqual(engine.active_player_id, self.player1)
+
+    engine.handle_game_message(self.player1, GameAction.EffectResolution_MakeChoice, { "choice_index": 0 })
+
+    # Events
+    events = engine.grab_events()
+    validate_consecutive_events(self, self.player1, events, [
+      (EventType.EventType_RollDie, { "die_result": 1, "rigged": False }),
+      (EventType.EventType_Decision_SendCheer, {}) # triggered since we have a card in the cheer deck
+    ])
+
+
+  def test_hSD01_009_azki_will_stay_the_same_orientation_when_sent_back_from_collab_effect(self):
+    # QnA: Q8 (2024.09.21)
+
+    engine = self.engine
+
+    p1: PlayerState = engine.get_player(self.player1)
+
+    p1.backstage = p1.backstage[1:5]
+    collab_card = put_card_in_play(self, p1, "hSD01-009", p1.backstage)
+
+    p1.cheer_deck = [] # empty cheer deck
+
+    # Events
+    events = do_collab_get_events(self, p1, collab_card["game_card_id"])
+    validate_consecutive_events(self, self.player1, events, [
+      (EventType.EventType_Collab, { "collab_card_id": collab_card["game_card_id"] }),
+      (EventType.EventType_Decision_Choice, {})
+    ])
+
+
+    """Test"""
+    self.assertEqual(engine.active_player_id, self.player1)
+
+    engine.handle_game_message(self.player1, GameAction.EffectResolution_MakeChoice, { "choice_index": 0 })
+
+    # Events
+    events = engine.grab_events()
+    validate_consecutive_events(self, self.player1, events, [
+      (EventType.EventType_RollDie, { "die_result": 1, "rigged": False }),
+      (EventType.EventType_Choice_SendCollabBack, {})
+    ]) # events skipped moving cheer from cheer deck
+
+    self.assertFalse(collab_card["resting"]) # check that it is not resting and will be checked again after returning to backstage
+
+    engine.handle_game_message(self.player1, GameAction.EffectResolution_MakeChoice, { "choice_index": 1 })
+
+    # Events
+    events = engine.grab_events()
+    validate_consecutive_events(self, self.player1, events, [
+      (EventType.EventType_MoveCard, { "from_zone": "collab", "to_zone": "backstage" }),
+      (EventType.EventType_Decision_MainStep, {})
+    ])
+    self.assertEqual(len(p1.backstage), 5)
+    self.assertFalse(collab_card["resting"]) # the orientation did not change
+
+
+  def test_hSD01_009_cannot_collab_after_collab_send_back(self):
+    # QnA: Q9 (2024.09.21)
+
+    engine = self.engine
+
+    p1: PlayerState = engine.get_player(self.player1)
+
+    p1.backstage = p1.backstage[1:5]
+    collab_card = put_card_in_play(self, p1, "hSD01-009", p1.backstage)
+
+    p1.cheer_deck = [] # empty cheer deck
+
+    # Events
+    events = do_collab_get_events(self, p1, collab_card["game_card_id"])
+    validate_consecutive_events(self, self.player1, events, [
+      (EventType.EventType_Collab, { "collab_card_id": collab_card["game_card_id"] }),
+      (EventType.EventType_Decision_Choice, {})
+    ])
+
+
+    """Test"""
+    self.assertEqual(engine.active_player_id, self.player1)
+
+    engine.handle_game_message(self.player1, GameAction.EffectResolution_MakeChoice, { "choice_index": 0 })
+
+    # Events
+    events = engine.grab_events()
+    validate_consecutive_events(self, self.player1, events, [
+      (EventType.EventType_RollDie, { "die_result": 1, "rigged": False }),
+      (EventType.EventType_Choice_SendCollabBack, {})
+    ])
+
+    engine.handle_game_message(self.player1, GameAction.EffectResolution_MakeChoice, { "choice_index": 1 })
+
+    # Events
+    events = engine.grab_events()
+    validate_consecutive_events(self, self.player1, events, [
+      (EventType.EventType_MoveCard, { "from_zone": "collab", "to_zone": "backstage" }),
+      (EventType.EventType_Decision_MainStep, {})
+    ])
+    self.assertEqual(len(p1.backstage), 5)
+    # no collab as available action
+    self.assertFalse(any(action["action_type"] == GameAction.MainStepCollab for action in events[-2]["available_actions"]))

--- a/tests/hSD01/test_hsd01_009.py
+++ b/tests/hSD01/test_hsd01_009.py
@@ -5,9 +5,6 @@ from app.gameengine import PlayerState
 from app.gameengine import EventType
 from tests.helpers import *
 
-import json
-def jsonprint(data):
-  print(json.dumps(data, indent=4))
 
 class Test_hSD01_009(unittest.TestCase):
   engine: GameEngine

--- a/tests/hSD01/test_hsd01_011.py
+++ b/tests/hSD01/test_hsd01_011.py
@@ -1,0 +1,153 @@
+import unittest
+
+from app.gameengine import GameEngine, GameAction
+from app.gameengine import PlayerState
+from app.gameengine import EventType
+from tests.helpers import *
+
+
+class Test_hSD01_011(unittest.TestCase):
+  engine: GameEngine
+  player1: str
+  player2: str
+
+  def setUp(self):
+    initialize_game_to_third_turn(self)
+  
+
+  def test_hsd01_011_sorazgravity_works_with_soraz(self):
+    # QnA: Q10 (2024.09.21)
+    
+    engine = self.engine
+
+    p1: PlayerState = engine.get_player(self.player1)
+    p2: PlayerState = engine.get_player(self.player2)
+
+    # Setup to put hSD01-011 to center and collab with SorAZ
+    p1.center = []
+    center_card = put_card_in_play(self, p1, "hSD01-011", p1.center)
+    center_card_id = center_card["game_card_id"]
+    spawn_cheer_on_card(self, p1, center_card_id, "green", "g1")
+    spawn_cheer_on_card(self, p1, center_card_id, "green", "g2")
+    spawn_cheer_on_card(self, p1, center_card_id, "green", "g3")
+
+    p1.backstage = p1.backstage[1:]
+    collab_card = put_card_in_play(self, p1, "hSD01-013", p1.backstage)
+    collab_card_id = collab_card["game_card_id"]
+
+    # Events
+    events = do_collab_get_events(self, p1, collab_card_id)
+    validate_consecutive_events(self, self.player1, events, [
+      (EventType.EventType_Collab, { "collab_card_id": collab_card_id }),
+      (EventType.EventType_Decision_MainStep, {})
+    ])
+
+
+    """Test"""
+    self.assertEqual(engine.active_player_id, self.player1)
+
+    begin_performance(self)
+    engine.handle_game_message(self.player1, GameAction.PerformanceStepUseArt, {
+      "art_id": "sorazgravity",
+      "performer_id": center_card_id,
+      "target_id": p2.center[0]["game_card_id"]
+    })
+
+    # Events
+    events = engine.grab_events()
+    validate_consecutive_events(self, self.player1, events, [
+      (EventType.EventType_PerformArt, { "active_player": self.player1 }),
+      # bonus art effect triggered with soraz
+      (EventType.EventType_Decision_SendCheer, { "from_zone": "cheer_deck", "to_zone": "holomem" })
+    ])
+
+
+  def test_hsd01_011_sorazgravity_works_with_sora_cards(self):
+    engine = self.engine
+
+    p1: PlayerState = engine.get_player(self.player1)
+    p2: PlayerState = engine.get_player(self.player2)
+
+    # Setup to put hSD01-011 to center and collab with a sora card
+    p1.center = []
+    center_card = put_card_in_play(self, p1, "hSD01-011", p1.center)
+    center_card_id = center_card["game_card_id"]
+    spawn_cheer_on_card(self, p1, center_card_id, "green", "g1")
+    spawn_cheer_on_card(self, p1, center_card_id, "green", "g2")
+    spawn_cheer_on_card(self, p1, center_card_id, "green", "g3")
+
+    collab_card_id = p1.backstage[0]["game_card_id"]
+
+    # Events
+    events = do_collab_get_events(self, p1, collab_card_id)
+    validate_consecutive_events(self, self.player1, events, [
+      (EventType.EventType_Collab, { "collab_card_id": collab_card_id }),
+      (EventType.EventType_Decision_MainStep, {})
+    ])
+
+
+    """Test"""
+    self.assertEqual(engine.active_player_id, self.player1)
+
+    begin_performance(self)
+    engine.handle_game_message(self.player1, GameAction.PerformanceStepUseArt, {
+      "art_id": "sorazgravity",
+      "performer_id": center_card_id,
+      "target_id": p2.center[0]["game_card_id"]
+    })
+
+    # Events
+    events = engine.grab_events()
+    validate_consecutive_events(self, self.player1, events, [
+      (EventType.EventType_PerformArt, { "active_player": self.player1 }),
+      # bonus art effect triggered with soraz
+      (EventType.EventType_Decision_SendCheer, { "from_zone": "cheer_deck", "to_zone": "holomem" })
+    ])
+
+  def test_hSD01_011_sorazgravity_does_not_work_with_other_names(self):
+    engine = self.engine
+
+    p1: PlayerState = engine.get_player(self.player1)
+    p2: PlayerState = engine.get_player(self.player2)
+
+    # Setup to put hSD01-011 to center and collab with a non-sora card
+    p1.center = []
+    center_card = put_card_in_play(self, p1, "hSD01-011", p1.center)
+    center_card_id = center_card["game_card_id"]
+    spawn_cheer_on_card(self, p1, center_card_id, "green", "g1")
+    spawn_cheer_on_card(self, p1, center_card_id, "green", "g2")
+    spawn_cheer_on_card(self, p1, center_card_id, "green", "g3")
+
+    p1.backstage = [] # empty backstage
+    colalb_card = put_card_in_play(self, p1, "hSD01-008", p1.backstage)
+    collab_card_id = colalb_card["game_card_id"]
+
+    # Events
+    events = do_collab_get_events(self, p1, collab_card_id)
+    validate_consecutive_events(self, self.player1, events, [
+      (EventType.EventType_Collab, { "collab_card_id": collab_card_id }),
+      (EventType.EventType_Decision_MainStep, {})
+    ])
+
+    downed_holomem = p2.center[0] # holomem to be downed after the attack
+
+
+    """Test"""
+    self.assertEqual(engine.active_player_id, self.player1)
+
+    begin_performance(self)
+    engine.handle_game_message(self.player1, GameAction.PerformanceStepUseArt, {
+      "art_id": "sorazgravity",
+      "performer_id": center_card_id,
+      "target_id": p2.center[0]["game_card_id"]
+    })
+
+    # Events
+    events = engine.grab_events()
+    validate_consecutive_events(self, self.player1, events, [
+      (EventType.EventType_PerformArt, { "active_player": self.player1 }),
+      (EventType.EventType_DamageDealt, { "damage": 60 }), # bonus art effect not triggered
+      (EventType.EventType_DownedHolomem_Before, {}),
+      (EventType.EventType_DownedHolomem, { "target_id": downed_holomem["game_card_id"] }),
+      (EventType.EventType_Decision_SendCheer, { "from_zone": "life", "to_zone": "holomem" })
+    ])

--- a/tests/hSD01/test_hsd01_012.py
+++ b/tests/hSD01/test_hsd01_012.py
@@ -1,0 +1,76 @@
+import unittest
+
+from app.gameengine import GameEngine, GameAction
+from app.gameengine import PlayerState
+from app.gameengine import EventType
+from tests.helpers import *
+
+
+class Test_hSD01_012(unittest.TestCase):
+  engine: GameEngine
+  player1: str
+
+
+  def setUp(self):
+    initialize_game_to_third_turn(self)
+
+
+  def test_hSD01_012_collab_effect(self):
+    engine = self.engine
+
+    p1: PlayerState = engine.get_player(self.player1)
+
+    # Setup to put hSD01-012 on backstage to collab
+    p1.backstage = p1.backstage[1:]
+    collab_card = put_card_in_play(self, p1, "hSD01-012", p1.backstage)
+    collab_card_id = collab_card["game_card_id"]
+
+    # Spawn a green cheer to any holomem, then archive all
+    spawn_cheer_on_card(self, p1, collab_card_id, "green", "g1")
+    spawn_cheer_on_card(self, p1, collab_card_id, "red", "r1")
+    spawn_cheer_on_card(self, p1, collab_card_id, "blue", "b1")
+    spawn_cheer_on_card(self, p1, collab_card_id, "white", "w1")
+    p1.archive_attached_cards(p1.get_cheer_ids_on_holomems())
+
+    # Events
+    events = engine.grab_events()
+    validate_consecutive_events(self, self.player1, events, [
+      # two existing white cheer + 4 of each color
+      (EventType.EventType_MoveAttachedCard, { "to_holomem_id": "archive" }) for i in range(6)
+    ])
+
+
+    """Test"""
+    self.assertEqual(engine.active_player_id, self.player1)
+
+    # Events
+    events = do_collab_get_events(self, p1, collab_card_id)
+    validate_consecutive_events(self, self.player1, events, [
+      (EventType.EventType_Collab, { "collab_card_id": collab_card_id }),
+      # decision to send cheer is triggered
+      (EventType.EventType_Decision_SendCheer, { "from_zone": "archive", "to_zone": "holomem" })
+    ])
+
+    # 2 existing white cards + 1 white and 1 green, proving the color restriction of the effect works
+    self.assertEqual(len(events[-2]["from_options"]), 4)
+
+
+  def test_hSD01_012_collab_effect_fizzles_out_when_no_target_in_archive(self):
+    engine = self.engine
+
+    p1: PlayerState = engine.get_player(self.player1)
+
+    # Setup to put hSD01-012 on backstage to collab
+    p1.backstage = p1.backstage[1:]
+    collab_card = put_card_in_play(self, p1, "hSD01-012", p1.backstage)
+    collab_card_id = collab_card["game_card_id"]
+
+    """Test"""
+    self.assertEqual(engine.active_player_id, self.player1)
+
+    # Events
+    events = do_collab_get_events(self, p1, collab_card_id)
+    validate_consecutive_events(self, self.player1, events, [
+      (EventType.EventType_Collab, { "collab_card_id": collab_card_id }),
+      (EventType.EventType_Decision_MainStep, {}) # skip straight back to main step
+    ])

--- a/tests/hSD01/test_hsd01_013.py
+++ b/tests/hSD01/test_hsd01_013.py
@@ -1,0 +1,229 @@
+import unittest
+
+from app.gameengine import GameEngine, GameAction
+from app.gameengine import PlayerState
+from app.gameengine import EffectType
+from tests.helpers import *
+
+
+class Test_hSD01_013(unittest.TestCase):
+  engine: GameEngine
+  player1: str
+  player2: str
+
+
+  def setUp(self):
+    p1_deck = generate_deck_with("", { "hBP01-124": 4, "hSD01-021": 1 })
+    initialize_game_to_third_turn(self, p1_deck)
+
+
+  # QnA: Q5 covered by hSD01-006
+  # QnA: Q10 covered by hSD01-011
+
+  def test_hSD01_013_brighterfuture_will_work_even_with_empty_deck(self):
+    # QnA: Q11 (2024.09.21)
+    
+    engine = self.engine
+
+    p1: PlayerState = engine.get_player(self.player1)
+    p2: PlayerState = engine.get_player(self.player2)
+
+    # Setup to have soraz in the center and have empty deck and cheer deck
+    p1.center = []
+    center_card = put_card_in_play(self, p1, "hSD01-013", p1.center)
+    center_card_id = center_card["game_card_id"]
+
+    spawn_cheer_on_card(self, p1, center_card_id, "white", "w1")
+    spawn_cheer_on_card(self, p1, center_card_id, "white", "w2")
+
+    p1.deck = []
+    """Test"""
+    self.assertEqual(engine.active_player_id, self.player1)
+
+    begin_performance(self)
+    engine.handle_game_message(self.player1, GameAction.PerformanceStepUseArt, { 
+      "art_id": "brighterfuture",
+      "performer_id": center_card_id,
+      "target_id": p2.center[0]["game_card_id"]
+    })
+
+    # Events
+    events = engine.grab_events()
+    validate_consecutive_events(self, self.player1, events, [
+      (EventType.EventType_PerformArt, {}),
+      (EventType.EventType_Decision_Choice, {})
+    ])
+
+    # Override random chance
+    self.random_override.random_values = [2]
+
+    engine.handle_game_message(self.player1, GameAction.EffectResolution_MakeChoice, { "choice_index": 0 })
+
+    # Events
+    events = engine.grab_events()
+    validate_consecutive_events(self, self.player1, events, [
+      (EventType.EventType_RollDie, { "die_result": 2 }),
+      (EventType.EventType_Draw, { "drawn_card_ids": [] }), # no cards drawn, game continues
+      (EventType.EventType_DamageDealt, { "damage": 50 })
+    ] + end_turn_events())
+
+
+  def test_hSD01_013_brighterfuture_will_work_even_with_empty_cheer_deck(self):
+    # QnA: Q11 (2024.09.21)
+    
+    engine = self.engine
+
+    p1: PlayerState = engine.get_player(self.player1)
+    p2: PlayerState = engine.get_player(self.player2)
+
+    # Setup to have soraz in the center and have empty deck and cheer deck
+    p1.center = []
+    center_card = put_card_in_play(self, p1, "hSD01-013", p1.center)
+    center_card_id = center_card["game_card_id"]
+
+    spawn_cheer_on_card(self, p1, center_card_id, "white", "w1")
+    spawn_cheer_on_card(self, p1, center_card_id, "white", "w2")
+    
+    p1.cheer_deck = []
+
+    """Test"""
+    self.assertEqual(engine.active_player_id, self.player1)
+
+    begin_performance(self)
+    engine.handle_game_message(self.player1, GameAction.PerformanceStepUseArt, { 
+      "art_id": "brighterfuture",
+      "performer_id": center_card_id,
+      "target_id": p2.center[0]["game_card_id"]
+    })
+
+    # Events
+    events = engine.grab_events()
+    validate_consecutive_events(self, self.player1, events, [
+      (EventType.EventType_PerformArt, {}),
+      (EventType.EventType_Decision_Choice, {})
+    ])
+
+    engine.handle_game_message(self.player1, GameAction.EffectResolution_MakeChoice, { "choice_index": 0 })
+
+    # Events
+    events = engine.grab_events()
+    validate_consecutive_events(self, self.player1, events, [
+      (EventType.EventType_RollDie, { "die_result": 1 }),
+      # skipped the effect since cheer deck is empty
+      (EventType.EventType_DamageDealt, { "damage": 50 }),
+    ] + end_turn_events())
+    
+
+  
+  def test_hSD01_013_BOTH_of_koyori_collab_effect_will_trigger_with_soraz(self):
+    # QnA: Q13 (2024.09.21)
+
+    engine = self.engine
+
+    p1: PlayerState = engine.get_player(self.player1)
+
+    # Setup to have koyori collaborate with soraz in the center
+    p1.center = []
+    put_card_in_play(self, p1, "hSD01-013", p1.center)
+
+    p1.backstage.pop()
+    collab_card = put_card_in_play(self, p1, "hSD01-015", p1.backstage)
+    collab_card_id = collab_card["game_card_id"]
+
+    
+    """Test"""
+    self.assertEqual(engine.active_player_id, self.player1)
+
+    # Events
+    events = do_collab_get_events(self, p1, collab_card_id)
+    validate_consecutive_events(self, self.player1, events, [
+      (EventType.EventType_Collab, { "collab_card_id": collab_card_id }),
+      (EventType.EventType_Draw, {}), # koyori-sora effect
+      (EventType.EventType_MoveAttachedCard, {}), # koyori-azki effect
+      (EventType.EventType_Decision_MainStep, {})
+    ])
+
+
+  def test_hSD01_013_first_gravity_can_be_used_to_on_soraz(self):
+    # QnA: Q17 (2024.09.21)
+
+    engine = self.engine
+    
+    p1: PlayerState = engine.get_player(self.player1)
+
+    # Setup to have soraz on top of the deck, and first gravity in hand
+    target_card = add_card_to_hand(self, p1, "hSD01-013")
+    target_card_id = target_card["game_card_id"]
+    p1.hand.pop()
+    p1.deck.insert(0, target_card)
+
+    support_card = add_card_to_hand(self, p1, "hSD01-021")
+    support_card_id = support_card["game_card_id"]
+
+
+    """Test"""
+    self.assertEqual(engine.active_player_id, self.player1)
+
+    engine.handle_game_message(self.player1, GameAction.MainStepPlaySupport, { "card_id": support_card_id })
+
+    # Events
+    events = engine.grab_events()
+    validate_consecutive_events(self, self.player1, events, [
+      (EventType.EventType_PlaySupportCard, {}),
+      (EventType.EventType_Decision_ChooseCards, { "from_zone": "deck", "to_zone": "hand" })
+    ])
+    # soraz can be chosen by first gravity
+    self.assertTrue(target_card_id in events[-2]["cards_can_choose"])
+
+
+  def test_hSD01_013_pioneer_fan_will_be_archived_when_soraz_blooms_into_sora(self):
+    # QnA: Q116 (2024.09.21)
+
+    engine = self.engine
+
+    p1: PlayerState = engine.get_player(self.player1)
+
+    # Setup to have soraz in center, equipped with pioneer, and a card to bloom into
+    p1.center = []
+    center_card = put_card_in_play(self, p1, "hSD01-013", p1.center)
+    center_card_id = center_card["game_card_id"]
+
+    fan_card = add_card_to_hand(self, p1, "hBP01-124")
+    fan_card_id = fan_card["game_card_id"]
+
+    bloom_card = add_card_to_hand(self, p1, "hSD01-006")
+    bloom_card_id = bloom_card["game_card_id"]
+
+    engine.handle_game_message(self.player1, GameAction.MainStepPlaySupport, { "card_id": fan_card_id })
+
+    # Events
+    events = engine.grab_events()
+    validate_consecutive_events(self, self.player1, events, [
+      (EventType.EventType_PlaySupportCard, {}),
+      (EventType.EventType_Decision_ChooseHolomemForEffect, {})
+    ])
+    
+    engine.handle_game_message(self.player1, GameAction.EffectResolution_ChooseCardsForEffect, { "card_ids": [center_card_id] })
+
+    # Events
+    events = engine.grab_events()
+    validate_consecutive_events(self, self.player1, events, [
+      (EventType.EventType_MoveCard, { "from_zone": "floating", "to_zone": "holomem" }),
+      (EventType.EventType_Decision_MainStep, {})
+    ])
+    self.assertEqual(len(center_card["attached_support"]), 1)
+
+    
+    """Test"""
+    self.assertEqual(engine.active_player_id, self.player1)
+
+    engine.handle_game_message(self.player1, GameAction.MainStepBloom, { "card_id": bloom_card_id, "target_id": center_card_id })
+
+    # Events
+    events = engine.grab_events()
+    validate_consecutive_events(self, self.player1, events, [
+      (EventType.EventType_Bloom, { "bloom_card_id": bloom_card_id }),
+      # fan card is removed because card now no longer is a valid card
+      (EventType.EventType_MoveCard, { "from_zone": bloom_card_id, "to_zone": "archive" }),
+      (EventType.EventType_Decision_MainStep, {})
+    ])

--- a/tests/hSD01/test_hsd01_017.py
+++ b/tests/hSD01/test_hsd01_017.py
@@ -1,0 +1,43 @@
+import unittest
+
+from app.gameengine import GameEngine, GameAction
+from app.gameengine import PlayerState
+from app.gameengine import EventType
+from tests.helpers import *
+
+
+class Test_hSD01_017(unittest.TestCase):
+  engine: GameEngine
+  player1: str
+
+  def setUp(self):
+    initialize_game_to_third_turn(self)
+
+  
+  def test_hSD01_017_need_at_least_one_card_other_than_manechan_to_activate(self):
+    # QnA: Q14 (2024.09.21)
+
+    engine = self.engine
+
+    p1: PlayerState = engine.get_player(self.player1)
+
+    # Setup to have mane-chan on hand with no other cards
+    p1.hand = []
+    add_card_to_hand(self, p1, "hSD01-017")
+
+    """Test"""
+    self.assertEqual(engine.active_player_id, self.player1)
+    self.assertEqual(len(p1.hand), 1)
+
+    main_step_event = engine.all_events[-2]
+    self.assertEqual(main_step_event["active_player"], self.player1)
+
+    validate_actions(self, main_step_event["available_actions"], [
+      GameAction.MainStepBloom for _ in range((len(p1.backstage) + len(p1.center)) * 2)
+    ] + [
+      GameAction.MainStepCollab for _ in range(len(p1.backstage))
+    ] + [
+      GameAction.MainStepBatonPass,
+      GameAction.MainStepBeginPerformance,
+      GameAction.MainStepEndTurn
+    ]) # no available action to use mane-chan

--- a/tests/hSD01/test_hsd01_019.py
+++ b/tests/hSD01/test_hsd01_019.py
@@ -6,36 +6,37 @@ from app.gameengine import EventType
 from tests.helpers import *
 
 
-class Test_hSD01_017(unittest.TestCase):
+class Test_hSD01_019(unittest.TestCase):
   engine: GameEngine
   player1: str
+
 
   def setUp(self):
     initialize_game_to_third_turn(self)
 
-  
-  def test_hSD01_017_need_at_least_one_card_other_than_manechan_to_activate(self):
-    # QnA: Q14 (2024.09.21)
+
+  def test_hSD01_019_can_only_archive_cheers_on_stage_not_on_cheer_deck(self):
+    # QnA: Q15 (2024.09.21)
 
     engine = self.engine
 
     p1: PlayerState = engine.get_player(self.player1)
 
-    # Setup to have mane-chan on hand with no other cards
-    p1.hand = []
-    add_card_to_hand(self, p1, "hSD01-017")
+    # Setup to have amazing pc on hand without cheers on stage
+    add_card_to_hand(self, p1, "hSD01-019")
+
+    p1.archive_attached_cards(p1.get_cheer_ids_on_holomems())
 
     """Test"""
     self.assertEqual(engine.active_player_id, self.player1)
-    self.assertEqual(len(p1.hand), 1)
 
+    reset_mainstep(self)
     main_step_event = engine.all_events[-1]
-    self.assertEqual(main_step_event["active_player"], self.player1)
-
-    validate_actions(self, main_step_event["available_actions"],[
+    validate_actions(self, main_step_event["available_actions"], [
+      GameAction.MainStepBloom for _ in range(2 * (len(p1.backstage) + len(p1.center)))
+    ] + [
       GameAction.MainStepCollab for _ in range(len(p1.backstage))
     ] + [
-      GameAction.MainStepBatonPass,
       GameAction.MainStepBeginPerformance,
       GameAction.MainStepEndTurn
-    ]) # no available action to use mane-chan
+    ]) # no action available to activate amazing pc since no cheer on stage

--- a/tests/hSD01/test_hsd01_020.py
+++ b/tests/hSD01/test_hsd01_020.py
@@ -1,0 +1,68 @@
+import unittest
+
+from app.gameengine import GameEngine, GameAction
+from app.gameengine import PlayerState
+from app.gameengine import EventType
+from tests.helpers import *
+
+
+class Test_hSD01_020(unittest.TestCase):
+  engine: GameEngine
+  player1: str
+  player2: str
+
+  
+  def setUp(self):
+    p1_deck = generate_deck_with("", { "hBP01-015": 1 })
+    initialize_game_to_third_turn(self, p1_deck)
+
+
+  def test_hSD01_020_failed_dice_roll_still_activates_mumei_damage_boost(self):
+    # QnA: Q50 (2024.09.21)
+
+    engine = self.engine
+
+    p1: PlayerState = engine.get_player(self.player1)
+    p2: PlayerState = engine.get_player(self.player2)
+
+    # Setup to have mumei in the center and holofan circle in hand
+    p1.center = []
+    center_card = put_card_in_play(self, p1, "hBP01-015", p1.center)
+    center_card_id = center_card["game_card_id"]
+    spawn_cheer_on_card(self, p1, center_card_id, "white", "w1")
+    
+    support_card = add_card_to_hand(self, p1, "hSD01-020")
+    support_card_id = support_card["game_card_id"]
+
+
+    """Test"""
+    self.assertEqual(engine.active_player_id, self.player1)
+
+    engine.handle_game_message(self.player1, GameAction.MainStepPlaySupport, { "card_id": support_card_id })
+
+    # Events
+    events = engine.grab_events()
+    validate_consecutive_events(self, self.player1, events, [
+      (EventType.EventType_PlaySupportCard, {}),
+      (EventType.EventType_RollDie, {}),
+      (EventType.EventType_MoveCard, { "from_zone": "floating", "to_zone": "archive" }),
+      (EventType.EventType_Decision_MainStep, {}) # dice roll failed as expected
+    ])
+
+    begin_performance(self)
+    engine.handle_game_message(self.player1, GameAction.PerformanceStepUseArt, {
+      "art_id": "ohhi",
+      "performer_id": center_card_id,
+      "target_id": p2.center[0]["game_card_id"]
+    })
+
+    # Events
+    center_art = 10
+    art_boost = 20
+
+    events = engine.grab_events()
+    validate_consecutive_events(self, self.player1, events, [
+      (EventType.EventType_PerformArt, { "power": center_art }),
+      (EventType.EventType_BoostStat, { "amount": art_boost }), # art boost was still triggered
+      (EventType.EventType_DamageDealt, { "damage": center_art + art_boost })
+    ] + end_turn_events())

--- a/tests/hSD01/test_hsd01_021.py
+++ b/tests/hSD01/test_hsd01_021.py
@@ -1,0 +1,50 @@
+import unittest
+
+from app.gameengine import GameEngine, GameAction
+from app.gameengine import PlayerState
+from app.gameengine import EventType
+from tests.helpers import *
+
+
+class Test_hSD01_021(unittest.TestCase):
+  engine: GameEngine
+  player1: str
+
+  def setUp(self):
+    initialize_game_to_third_turn(self)
+
+  
+  # QnA: Q17 is covered by hSD01-013
+
+
+  def test_hSD01_021_can_be_used_when_you_have_six_other_cards_in_hand(self):
+    # QnA: Q16 (2024.09.21)
+
+    engine = self.engine
+
+    p1: PlayerState = engine.get_player(self.player1)
+
+    # Setup to have first gravity and six cards in hand
+    self.assertEqual(len(p1.hand), 3)
+    p1.hand = p1.hand + p1.deck[:3]
+    p1.deck = p1.deck[3:]
+    self.assertEqual(len(p1.hand), 6)
+
+    add_card_to_hand(self, p1, "hSD01-021")
+    self.assertEqual(len(p1.hand), 7) # hand now has 1 debut, 5 1st bloom and first gravity
+
+
+    """Test"""
+    self.assertEqual(engine.active_player_id, self.player1)
+
+    main_step_event = engine.all_events[-1]
+    validate_actions(self, main_step_event["available_actions"], [
+      GameAction.MainStepBloom for _ in range(5 * (len(p1.backstage) + len(p1.center)))
+    ] + [
+      GameAction.MainStepCollab for _ in range(len(p1.backstage))
+    ] + [
+      GameAction.MainStepPlaySupport, # first gravity can be activated with 6 cards in hand excluding itself
+      GameAction.MainStepBatonPass,
+      GameAction.MainStepBeginPerformance,
+      GameAction.MainStepEndTurn
+    ])

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -358,3 +358,6 @@ def generate_deck_with(oshi_id, cards : dict[str, int] = [], cheer = []):
             deck[card_id] = count
 
     return new_deck
+
+def jsonprint(data):
+    print(json.dumps(data, indent=4))

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -46,7 +46,7 @@ def validate_event(self : unittest.TestCase, event, event_type, event_player_id,
     for key, value in event_data.items():
         self.assertEqual(event[key], value)
 
-def validate_consecutive_events(self: unittest.TestCase, player_id: str, for_events: list, against_data: list[(str, dict)]):
+def validate_consecutive_events(self: unittest.TestCase, player_id: str, for_events: list, against_data: list[(EventType, dict)]):
     player_events = list(filter(lambda event: event["event_player_id"] == player_id, for_events))
 
     self.assertGreater(len(player_events), 0, f"No events for {player_id}")
@@ -361,3 +361,16 @@ def generate_deck_with(oshi_id, cards : dict[str, int] = [], cheer = []):
 
 def jsonprint(data):
     print(json.dumps(data, indent=4))
+
+# generates events that occurs from end turn to next player's turn
+def end_turn_events(for_validation=True) -> list:
+    events = [
+        EventType.EventType_EndTurn,
+        EventType.EventType_TurnStart,
+        EventType.EventType_ResetStepActivate,
+        EventType.EventType_ResetStepCollab,
+        EventType.EventType_Draw,
+        EventType.EventType_CheerStep,
+    ]
+
+    return [(event, {}) if for_validation else events for event in events]

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -46,6 +46,17 @@ def validate_event(self : unittest.TestCase, event, event_type, event_player_id,
     for key, value in event_data.items():
         self.assertEqual(event[key], value)
 
+def validate_consecutive_events(self: unittest.TestCase, player_id: str, for_events: list, against_data: list[(str, dict)]):
+    player_events = list(filter(lambda event: event["event_player_id"] == player_id, for_events))
+
+    self.assertGreater(len(player_events), 0, f"No events for {player_id}")
+    self.assertEqual(len(player_events), len(against_data), f"Events to compare are not equal")
+
+    for event, data in zip(player_events, against_data):
+        event_type, event_data = data
+        validate_event(self, event, event_type, player_id, event_data)
+
+
 def validate_actions(self : unittest.TestCase, actions, expected_actions):
     self.assertEqual(len(actions), len(expected_actions))
     for i in range(len(actions)):


### PR DESCRIPTION
From the tests written, only one scenario needed to be fixed (fix included in this PR).

*  (Q1) hSD01-001 - Oshi: Tokino Sora
    - The player will be soft locked when they use the oshi skill "Replacement" with no cheers on stage. The action menu will pop open but you cannot select any holomem and no way to cancel the skill or exit the menu.