### PR TITLE
Pavolia Reine hbp02-018 to 023 & bakuhatsunomahou hbp02-079 & Tatang hbp02-094

### DIFF
--- a/app/gameengine.py
+++ b/app/gameengine.py
@@ -406,6 +406,7 @@ class PlayerState:
         self.effects_used_this_turn = []
         self.effects_used_this_game = []
         self.used_limited_this_turn = False
+        self.event_card_whit_magic_tag = False
         self.played_support_this_turn = False
         self.played_support_types_this_turn = {}
         self.turn_effects = []
@@ -994,6 +995,7 @@ class PlayerState:
         self.turn_effects = []
         self.performance_attacked_this_turn = False
         self.used_limited_this_turn = False
+        self.event_card_whit_magic_tag = False
         self.played_support_this_turn = False
         self.played_support_types_this_turn = {}
         self.effects_used_this_turn = []
@@ -1366,6 +1368,9 @@ def attach_card(attaching_card, target_card):
 
 def is_card_limited(card):
     return "limited" in card and card["limited"]
+    
+def is_event_card_whit_magic_tag_limited(card):
+    return "magic_limited" in card and card["magic_limited"]
 
 def is_card_attach_requirements_meant(attachment, card):
     if "effects" in attachment:
@@ -1955,6 +1960,11 @@ class GameEngine:
                     if active_player.used_limited_this_turn:
                         continue
                     if self.first_turn_player_id == active_player.player_id and active_player.first_turn:
+                        continue
+
+                # event card whit magic tag limited can only be used once per turn
+                if is_event_card_whit_magic_tag_limited(card):
+                    if active_player.event_card_whit_magic_tag:
                         continue
 
                 if "play_conditions" in card:
@@ -5135,6 +5145,9 @@ class GameEngine:
         player.played_support_types_this_turn[card["sub_type"]] = amount_of_type_played + 1
         if is_card_limited(card):
             player.used_limited_this_turn = True
+
+        if is_event_card_whit_magic_tag_limited(card):
+            player.event_card_whit_magic_tag = True
 
         card_effects = card["effects"]
         add_ids_to_effects(card_effects, player.player_id, card_id)

--- a/app/gameengine.py
+++ b/app/gameengine.py
@@ -69,6 +69,7 @@ class EffectType:
     EffectType_PowerBoostPerAllFans = "power_boost_per_all_fans"
     EffectType_PowerBoostPerAllMascots = "power_boost_per_all_mascots"
     EffectType_PowerBoostPerArchivedHolomem = "power_boost_per_archived_holomem"
+    EffectType_PowerBoostPerAllCheerColorTypes = "power_boost_per_all_cheer_color_types"
     EffectType_PowerBoostPerAttachedCheer = "power_boost_per_attached_cheer"
     EffectType_PowerBoostPerBackstage = "power_boost_per_backstage"
     EffectType_PowerBoostPerHolomem = "power_boost_per_holomem"
@@ -147,6 +148,7 @@ class Condition:
     Condition_PlayedSupportThisTurn = "played_support_this_turn"
     Condition_RevealedCardsCount = "revealed_cards_count"
     Condition_RevealedCardsHaveSameType = "revealed_cards_have_same_type"
+    Condition_SelfStageHasCheerColorTypes = "self_stage_has_cheer_color_types"
     Condition_SelfHasCheerColor = "self_has_cheer_color"
     Condition_StageHasSpace = "stage_has_space"
     Condition_TargetColor = "target_color"
@@ -762,6 +764,13 @@ class PlayerState:
                         effects.append(attached_effect)
         return effects
 
+    def get_cheer_color_types_on_holomems(self):
+        cheer_color_types = set()
+        for card in self.get_holomem_on_stage():
+            for attached_card in card["attached_cheer"]:
+                if is_card_cheer(attached_card):
+                    cheer_color_types.update(attached_card["colors"])
+        return cheer_color_types
 
     def get_cheer_ids_on_holomems(self):
         cheer_ids = []
@@ -1309,6 +1318,10 @@ class PlayerState:
                 damage_dealt = self.engine.after_damage_state.damage_dealt
                 healed_amount = 10 * (damage_dealt // 10)
                 healed_amount = min(healed_amount, card["damage"])
+        elif amount == "restore_hp_per_cheer_color_types_10s":
+            multiplier = len(self.get_cheer_color_types_on_holomems())
+            healed_amount = 10 * multiplier
+            healed_amount = min(healed_amount, card["damage"])
         else:
             healed_amount = min(amount, card["damage"])
         if healed_amount > 0:
@@ -2843,6 +2856,12 @@ class GameEngine:
                         bloom_level = base_card.get("bloom_level", 0)
                         return all([card["card_type"] == card_type and card.get("bloom_level", 0) == bloom_level for card in revealed_cards[1:]])
                 return False
+            case Condition.Condition_SelfStageHasCheerColorTypes:
+                amount_min = condition["amount_min"]
+                source_card, _, _ = effect_player.find_card(source_card_id)
+                if source_card:
+                    return amount_min <= len(effect_player.get_cheer_color_types_on_holomems())
+                return False
             case Condition.Condition_SelfHasCheerColor:
                 condition_colors = condition["condition_colors"]
                 amount_min = condition["amount_min"]
@@ -3878,6 +3897,11 @@ class GameEngine:
                 per_amount = effect["amount"]
                 holomems_in_archive = [card for card in effect_player.archive if is_card_holomem(card)]
                 total = per_amount * len(holomems_in_archive)
+                self.handle_power_boost(total, effect["source_card_id"])
+            case EffectType.EffectType_PowerBoostPerAllCheerColorTypes:
+                per_amount = effect["amount"]
+                multiplier = len(effect_player.get_cheer_color_types_on_holomems())
+                total = per_amount * multiplier
                 self.handle_power_boost(total, effect["source_card_id"])
             case EffectType.EffectType_PowerBoostPerAttachedCheer:
                 per_amount = effect["amount"]

--- a/decks/card_definitions.json
+++ b/decks/card_definitions.json
@@ -9994,6 +9994,7 @@
         "sub_type": "event",
         "card_names": ["bakuhatsunomahou"],
         "rarity": "u",
+        "magic_limited": true,
         "tags":["#Magic"],
         "effects": [
             {

--- a/decks/card_definitions.json
+++ b/decks/card_definitions.json
@@ -8684,6 +8684,234 @@
         ]
     },
     {
+    "card_id": "hBP02-018",
+    "card_type": "holomem_debut",
+    "card_names": ["pavolia_reine"],
+    "special_deck_limit": 50,
+    "rarity": "c",
+    "colors": ["green"],
+    "hp": 100,
+    "baton_cost": 1,
+    "tags": [
+        "#ID",
+        "#IDGen2",
+        "#Bird",
+        "#Art"
+    ],
+    "arts": [
+        {
+            "art_id": "peruhatelian",
+            "costs": [
+                { "color": "any", "amount": 1 }
+            ],
+            "power": 30
+        }
+    ]
+    },
+    {
+        "card_id": "hBP02-019",
+        "card_type": "holomem_debut",
+        "card_names": ["pavolia_reine"],
+        "rarity": "u",
+        "colors": ["green"],
+        "hp": 60,
+        "baton_cost": 1,
+        "tags": [
+            "#ID",
+            "#IDGen2",
+            "#Bird",
+            "#Art"
+        ],
+        "arts": [
+            {
+                "art_id": "veryeasy",
+                "costs": [
+                    { "color": "any", "amount": 1 }
+                ],
+                "power": 20
+            }
+        ],
+        "collab_effects": [
+            {
+                "effect_type": "send_cheer",
+                "amount_min": 1,
+                "amount_max": 1,
+                "from": "archive",
+                "to": "holomem"
+            }
+        ]
+    },
+    {
+        "card_id": "hBP02-020",
+        "card_type": "holomem_bloom",
+        "bloom_level": 1,
+        "card_names": ["pavolia_reine"],
+        "rarity": "c",
+        "colors": ["green"],
+        "hp": 160,
+        "baton_cost": 1,
+        "tags": [
+            "#ID",
+            "#IDGen2",
+            "#Bird",
+            "#Art"
+        ],
+        "arts": [
+            {
+                "art_id": "royalhalusleepover",
+                "costs": [
+                    { "color": "green", "amount": 1 },
+                    { "color": "any", "amount": 1 }
+                ],
+                "power": 50
+            }
+        ]
+    },
+    {
+        "card_id": "hBP02-021",
+        "card_type": "holomem_bloom",
+        "bloom_level": 1,
+        "card_names": ["pavolia_reine"],
+        "rarity": "u",
+        "colors": ["green"],
+        "hp": 120,
+        "baton_cost": 1,
+        "tags": [
+            "#ID",
+            "#IDGen2",
+            "#Bird",
+            "#Art"
+        ],
+        "arts": [
+            {
+                "art_id": "dakaramiteteneutatteodorimasu",
+                "costs": [
+                    { "color": "any", "amount": 1 }
+                ],
+                "power": 20,
+                "art_effects": [
+                    {
+                        "timing": "before_art",
+                        "effect_type": "send_cheer",
+                        "amount_min": 1,
+                        "amount_max": 1,
+                        "from": "archive",
+                        "to": "holomem"
+                    }
+                ]
+            }
+        ],
+        "bloom_effects": [
+            {
+                "effect_type": "choice",
+                "choice": [
+                    {
+                        "effect_type": "restore_hp",
+                        "target": "holomem",
+                        "amount": "restore_hp_per_cheer_color_types_10s"
+                    },
+                    { "effect_type": "pass" }
+                ]
+            }
+        ]
+    },
+    {
+        "card_id": "hBP02-022",
+        "card_type": "holomem_bloom",
+        "bloom_level": 1,
+        "card_names": ["pavolia_reine"],
+        "rarity": "r",
+        "colors": ["green"],
+        "hp": 130,
+        "baton_cost": 1,
+        "tags": [
+            "#ID",
+            "#IDGen2",
+            "#Bird",
+            "#Art"
+        ],
+        "arts": [
+            {
+                "art_id": "spicynight",
+                "costs": [
+                    { "color": "green", "amount": 1 },
+                    { "color": "any", "amount": 1 }
+                ],
+                "power": 40,
+                "art_effects": [
+                    {
+                        "timing": "before_art",
+                        "conditions": [{ "condition": "self_stage_has_cheer_color_types", "amount_min": 2 }],
+                        "effect_type": "power_boost",
+                        "amount": 20
+                    }
+                ]
+            }
+        ],
+        "bloom_effects": [
+            {
+                "effect_type": "choose_cards",
+                "from": "deck",
+                "look_at": -1,
+                "destination": "hand",
+                "amount_min": 1,
+                "amount_max": 1,
+                "requirement": "specific_card",
+                "requirement_id": "hBP02-094",
+                "reveal_chosen": true,
+                "remaining_cards_action": "shuffle"
+            }
+        ]
+    },
+    {
+        "card_id": "hBP02-023",
+        "card_type": "holomem_bloom",
+        "bloom_level": 2,
+        "card_names": ["pavolia_reine"],
+        "rarity": "rr",
+        "colors": ["green"],
+        "hp": 190,
+        "baton_cost": 2,
+        "tags": [
+            "#ID",
+            "#IDGen2",
+            "#Bird",
+            "#Art"
+        ],
+        "arts": [
+            {
+                "art_id": "kujakunodansu",
+                "costs": [
+                    { "color": "green", "amount": 1 },
+                    { "color": "any", "amount": 3 }
+                ],
+                "power": 100,
+                "art_effects": [
+                    {
+                        "timing": "before_art",
+                        "effect_type": "power_boost",
+                        "amount": 50,
+                        "conditions": [{ "condition": "target_color", "color_requirement": "white" }]
+                    },
+                    {
+                        "timing": "before_art",
+                        "effect_type": "power_boost_per_all_cheer_color_types",
+                        "amount": 20
+                    }
+                ]
+            }
+        ],
+        "bloom_effects": [
+            {
+                "effect_type": "send_cheer",
+                "amount_min": 1,
+                "amount_max": 1,
+                "from": "cheer_deck",
+                "to": "holomem"
+            }
+        ]
+    },
+    {
         "card_id": "hBP02-024",
         "card_type": "holomem_debut",
         "card_names": ["ookami_mio"],
@@ -9760,6 +9988,25 @@
         ]
     },
     {
+        "card_id": "hBP02-079",
+        "card_type": "support",
+        "colors": [],
+        "sub_type": "event",
+        "card_names": ["bakuhatsunomahou"],
+        "rarity": "u",
+        "tags":["#Magic"],
+        "effects": [
+            {
+                "effect_type": "deal_damage",
+                "special": true,
+                "amount": 20,
+                "target": "center_or_collab",
+                "opponent": true,
+                "prevent_life_loss": true
+            }
+        ]
+    },
+    {
         "card_id": "hBP02-080",
         "card_type": "support",
         "sub_type": "event",
@@ -10022,6 +10269,32 @@
                     { "condition": "attached_owner_is_location", "condition_location": "backstage" }
                 ],
                 "amount": "all"
+            }
+        ]
+    },
+    {
+        "card_id": "hBP02-094",
+        "card_type": "support",
+        "sub_type": "mascot",
+        "card_names": ["tatang"],
+        "rarity": "c",
+        "colors": [],
+        "effects": [
+            { "effect_type": "attach_card_to_holomem" }
+        ],
+        "attached_effects": [
+            {
+                "timing": "before_art",
+                "effect_type": "power_boost",
+                "amount": 10
+            },
+            {
+                "timing": "check_hp",
+                "conditions": [
+                    { "condition": "attached_to", "required_member_name": "pavolia_reine" }
+                ],
+                "effect_type": "bonus_hp",
+                "amount": 30
             }
         ]
     },

--- a/tests/hBP02/test_hbp02_018.py
+++ b/tests/hBP02/test_hbp02_018.py
@@ -1,0 +1,119 @@
+import unittest
+from app.gameengine import GameEngine, GameAction
+from app.gameengine import PlayerState
+from app.gameengine import EventType
+from tests.helpers import *
+
+
+class Test_hBP02_018(unittest.TestCase):
+    engine: GameEngine
+    player1: str
+    player2: str
+
+
+    def setUp(self):
+        p1_deck = generate_deck_with("", {
+            "hBP02-018": 3, # debut Reine
+        })
+        p2_deck = generate_deck_with("", {
+            "hBP02-018": 3, # debut Reine
+        })
+        initialize_game_to_third_turn(self, p1_deck, p2_deck)
+
+    def test_hbp02_018_overall_check(self):
+        p1: PlayerState = self.engine.get_player(self.player1)
+        card = next((card for card in p1.deck if card["card_id"] == "hBP02-018"), None)
+        self.assertIsNotNone(card)
+
+        # check hp and tags
+        self.assertEqual(card["hp"], 100)
+        self.assertCountEqual(card["tags"], ["#ID", "#IDGen2", "#Bird", "#Art"])
+
+    def test_hbp02_018_peruhatelian(self):
+        engine = self.engine
+    
+        p1: PlayerState = engine.get_player(self.player1)
+        p2: PlayerState = engine.get_player(self.player2)
+
+        # Setup Reine in the center
+        p1.center = []
+        _, center_card_id = unpack_game_id(put_card_in_play(self, p1, "hBP02-018", p1.center))
+        spawn_cheer_on_card(self, p1, center_card_id, "green", "g1") # any color
+
+        """Test"""
+        self.assertEqual(engine.active_player_id, self.player1)
+
+        begin_performance(self)
+        engine.handle_game_message(self.player1, GameAction.PerformanceStepUseArt, {
+            "art_id": "peruhatelian",
+            "performer_id": center_card_id,
+            "target_id": p2.center[0]["game_card_id"]
+        })
+
+        # Events
+        events = engine.grab_events()
+        validate_consecutive_events(self, self.player1, events, [
+            (EventType.EventType_PerformArt, { "art_id": "peruhatelian", "power": 30 }),
+            (EventType.EventType_DamageDealt, { "damage": 30 }),
+            *end_turn_events()
+        ])
+
+    def test_hbp02_018_baton_pass(self):
+        engine = self.engine
+        
+        p1: PlayerState = engine.get_player(self.player1)
+
+        # Setup to have Reine in the center
+        p1.center = []
+        center_card, center_card_id = unpack_game_id(put_card_in_play(self, p1, "hBP02-018", p1.center))
+
+        """Test"""
+        self.assertEqual(engine.active_player_id, self.player1)
+
+        # no cheers to use baton pass
+        self.assertEqual(len(center_card["attached_cheer"]), 0)
+
+        # Events
+        actions = reset_mainstep(self)
+        self.assertIsNone(
+        next((action for action in actions if action["action_type"] == GameAction.MainStepBatonPass and action["center_id"] == center_card_id), None))
+
+        # with sufficient cheers
+        spawn_cheer_on_card(self, p1, center_card_id, "white", "w1") # any color
+        actions = reset_mainstep(self)
+        self.assertIsNotNone(
+        next((action for action in actions if action["action_type"] == GameAction.MainStepBatonPass and action["center_id"] == center_card_id), None))
+
+    def test_hbp02_018_downed_health(self):
+        engine = self.engine
+        
+        p1: PlayerState = engine.get_player(self.player1)
+        p2: PlayerState = engine.get_player(self.player2)
+        
+        # Setup to have player2 have Reine damaged in the center
+        p2.center = []
+        p2_center_card, p2_center_card_id = unpack_game_id(put_card_in_play(self, p2, "hBP02-018", p2.center))
+        p2_center_card["damage"] = p2_center_card["hp"] - 10
+
+        _, center_card_id = unpack_game_id(p1.center[0])
+
+        """Test"""
+        self.assertEqual(engine.active_player_id, self.player1)
+
+        begin_performance(self)
+        engine.handle_game_message(self.player1, GameAction.PerformanceStepUseArt, {
+        "art_id": "nunnun",
+        "performer_id": center_card_id,
+        "target_id": p2_center_card_id
+        })
+
+        # Events
+        events = engine.grab_events()
+        validate_consecutive_events(self, self.player1, events, [
+        (EventType.EventType_PerformArt, {}),
+        (EventType.EventType_DamageDealt, {}),
+        (EventType.EventType_DownedHolomem_Before, {}),
+        (EventType.EventType_DownedHolomem, { "life_lost": 1, "target_id": p2_center_card_id }),
+        (EventType.EventType_Decision_SendCheer, {})
+        ])
+

--- a/tests/hBP02/test_hbp02_019.py
+++ b/tests/hBP02/test_hbp02_019.py
@@ -1,0 +1,173 @@
+import unittest
+from app.gameengine import DecisionType, GameEngine, GameAction
+from app.gameengine import PlayerState
+from app.gameengine import EventType
+from tests.helpers import *
+
+class Test_hBP02_019(unittest.TestCase):
+    engine: GameEngine
+    player1: str
+    player2: str
+
+    def setUp(self):
+        p1_deck = generate_deck_with("", {
+            "hBP02-019": 3,
+        })
+        p2_deck = generate_deck_with("", {
+            "hBP02-019": 3,
+        })
+        initialize_game_to_third_turn(self, p1_deck, p2_deck)
+
+    def test_hbp02_019_overall_check(self):
+        p1: PlayerState = self.engine.get_player(self.player1)
+        card = next((card for card in p1.deck if card["card_id"] == "hBP02-019"), None)
+        self.assertIsNotNone(card)
+
+        # check hp and tags
+        self.assertEqual(card["hp"], 60)
+        self.assertCountEqual(card["tags"], ["#ID", "#IDGen2", "#Bird", "#Art"])
+
+    def test_hbp02_019_veryeasy(self):
+        engine = self.engine
+    
+        p1: PlayerState = engine.get_player(self.player1)
+        p2: PlayerState = engine.get_player(self.player2)
+
+        # Setup Reine in the center
+        p1.center = []
+        _, center_card_id = unpack_game_id(put_card_in_play(self, p1, "hBP02-019", p1.center))
+        spawn_cheer_on_card(self, p1, center_card_id, "green", "g1") # any color
+
+        """Test"""
+        self.assertEqual(engine.active_player_id, self.player1)
+
+        begin_performance(self)
+        engine.handle_game_message(self.player1, GameAction.PerformanceStepUseArt, {
+            "art_id": "veryeasy",
+            "performer_id": center_card_id,
+            "target_id": p2.center[0]["game_card_id"]
+        })
+
+        # Events
+        events = engine.grab_events()
+        validate_consecutive_events(self, self.player1, events, [
+            (EventType.EventType_PerformArt, { "art_id": "veryeasy", "power": 20 }),
+            (EventType.EventType_DamageDealt, { "damage": 20 }),
+            *end_turn_events()
+        ])
+
+    def test_hbp02_019_baton_pass(self):
+        engine = self.engine
+    
+        p1: PlayerState = engine.get_player(self.player1)
+
+        # Setup to have card in the center
+        p1.center = []
+        center_card, center_card_id = unpack_game_id(put_card_in_play(self, p1, "hBP02-019", p1.center))
+
+        """Test"""
+        self.assertEqual(engine.active_player_id, self.player1)
+
+        # no cheers to use baton pass
+        self.assertEqual(len(center_card["attached_cheer"]), 0)
+
+        # Events
+        actions = reset_mainstep(self)
+        self.assertIsNone(
+        next((action for action in actions if action["action_type"] == GameAction.MainStepBatonPass and action["center_id"] == center_card_id), None))
+
+        # with sufficient cheers
+        spawn_cheer_on_card(self, p1, center_card_id, "white", "w1") # any color
+        actions = reset_mainstep(self)
+        self.assertIsNotNone(
+        next((action for action in actions if action["action_type"] == GameAction.MainStepBatonPass and action["center_id"] == center_card_id), None))
+
+    def test_hbp02_019_downed_health(self):
+        engine = self.engine
+    
+        p1: PlayerState = engine.get_player(self.player1)
+        p2: PlayerState = engine.get_player(self.player2)
+        
+        # Setup to have player2 have card damaged in the center
+        p2.center = []
+        p2_center_card, p2_center_card_id = unpack_game_id(put_card_in_play(self, p2, "hBP02-019", p2.center))
+        p2_center_card["damage"] = p2_center_card["hp"] - 10
+
+        _, center_card_id = unpack_game_id(p1.center[0])
+
+        """Test"""
+        self.assertEqual(engine.active_player_id, self.player1)
+
+        begin_performance(self)
+        engine.handle_game_message(self.player1, GameAction.PerformanceStepUseArt, {
+        "art_id": "nunnun",
+        "performer_id": center_card_id,
+        "target_id": p2_center_card_id
+        })
+
+        # Events
+        events = engine.grab_events()
+        validate_consecutive_events(self, self.player1, events, [
+        (EventType.EventType_PerformArt, {}),
+        (EventType.EventType_DamageDealt, {}),
+        (EventType.EventType_DownedHolomem_Before, {}),
+        (EventType.EventType_DownedHolomem, { "life_lost": 1, "target_id": p2_center_card_id }),
+        (EventType.EventType_Decision_SendCheer, {})
+        ])
+
+    def test_hbp02_019_collab_effect(self):
+        engine = self.engine
+    
+        p1: PlayerState = engine.get_player(self.player1)
+
+        # Setup card in backstage
+        p1.backstage = []
+        _, collab_card_id = unpack_game_id(put_card_in_play(self, p1, "hBP02-019", p1.backstage))
+        valid_target_ids = ids_from_cards(p1.get_holomem_on_stage())
+
+        # Add multiple cheers to archive (5 cheers, 5 non-cheers)
+        cheer_cards = p1.cheer_deck[:5]
+        _, cheer_card_id = unpack_game_id(cheer_cards[0])
+        p1.archive = p1.deck[:5] + cheer_cards
+        p1.cheer_deck = p1.cheer_deck[5:]
+        p1.deck = p1.deck[:5]
+
+        """Test"""
+        self.assertEqual(engine.active_player_id, self.player1)
+
+        engine.handle_game_message(self.player1, GameAction.MainStepCollab, { "card_id": collab_card_id })
+        engine.handle_game_message(self.player1, GameAction.EffectResolution_MoveCheerBetweenHolomems, {
+            "placements": { cheer_card_id: collab_card_id }
+        })
+        
+        # Events
+        events = engine.grab_events()
+        validate_consecutive_events(self, self.player1, events, [
+            (EventType.EventType_Collab, { "collab_card_id": collab_card_id }),
+            (EventType.EventType_Decision_SendCheer, { "from_options": ids_from_cards(cheer_cards), "to_options": valid_target_ids }),
+            (EventType.EventType_MoveAttachedCard, { "from_holomem_id": "archive", "to_holomem_id": collab_card_id, "attached_id": cheer_card_id }),
+            (EventType.EventType_Decision_MainStep, {})
+        ])
+
+    def test_hbp02_019_collab_effect_no_cheer_in_archive(self):
+        engine = self.engine
+    
+        p1: PlayerState = engine.get_player(self.player1)
+
+        # Setup card in backstage
+        p1.backstage = []
+        _, collab_card_id = unpack_game_id(put_card_in_play(self, p1, "hBP02-019", p1.backstage))
+
+        p1.archive = []
+
+        """Test"""
+        self.assertEqual(engine.active_player_id, self.player1)
+
+        engine.handle_game_message(self.player1, GameAction.MainStepCollab, { "card_id": collab_card_id })
+        
+        # Events
+        events = engine.grab_events()
+        validate_consecutive_events(self, self.player1, events, [
+            (EventType.EventType_Collab, { "collab_card_id": collab_card_id }),
+            (EventType.EventType_Decision_MainStep, {})
+        ])

--- a/tests/hBP02/test_hbp02_020.py
+++ b/tests/hBP02/test_hbp02_020.py
@@ -1,0 +1,117 @@
+import unittest
+from app.gameengine import GameEngine, GameAction
+from app.gameengine import PlayerState
+from app.gameengine import EventType
+from tests.helpers import *
+
+class Test_hBP02_020(unittest.TestCase):
+    engine: GameEngine
+    player1: str
+    player2: str
+
+    def setUp(self):
+        p1_deck = generate_deck_with("", {
+            "hBP02-020": 3,
+        })
+        p2_deck = generate_deck_with("", {
+            "hBP02-020": 3,
+        })
+        initialize_game_to_third_turn(self, p1_deck, p2_deck)
+
+    def test_hbp02_020_overall_check(self):
+        p1: PlayerState = self.engine.get_player(self.player1)
+        card = next((card for card in p1.deck if card["card_id"] == "hBP02-020"), None)
+        self.assertIsNotNone(card)
+
+        # check hp and tags
+        self.assertEqual(card["hp"], 160)
+        self.assertCountEqual(card["tags"], ["#ID", "#IDGen2", "#Bird", "#Art"])
+
+    def test_hbp02_020_royalhalusleepover(self):
+        engine = self.engine
+    
+        p1: PlayerState = engine.get_player(self.player1)
+        p2: PlayerState = engine.get_player(self.player2)
+
+        # Setup Reine in the center
+        p1.center = []
+        _, center_card_id = unpack_game_id(put_card_in_play(self, p1, "hBP02-020", p1.center))
+        spawn_cheer_on_card(self, p1, center_card_id, "green", "g1") # green color
+        spawn_cheer_on_card(self, p1, center_card_id, "red", "r1") # any color
+
+        """Test"""
+        self.assertEqual(engine.active_player_id, self.player1)
+
+        begin_performance(self)
+        engine.handle_game_message(self.player1, GameAction.PerformanceStepUseArt, {
+            "art_id": "royalhalusleepover",
+            "performer_id": center_card_id,
+            "target_id": p2.center[0]["game_card_id"]
+        })
+
+        # Events
+        events = engine.grab_events()
+        validate_consecutive_events(self, self.player1, events, [
+            (EventType.EventType_PerformArt, { "art_id": "royalhalusleepover", "power": 50 }),
+            (EventType.EventType_DamageDealt, { "damage": 50 }),
+            *end_turn_events()
+        ])
+
+    def test_hbp02_020_baton_pass(self):
+        engine = self.engine
+    
+        p1: PlayerState = engine.get_player(self.player1)
+
+        # Setup to have card in the center
+        p1.center = []
+        center_card, center_card_id = unpack_game_id(put_card_in_play(self, p1, "hBP02-020", p1.center))
+
+        """Test"""
+        self.assertEqual(engine.active_player_id, self.player1)
+
+        # no cheers to use baton pass
+        self.assertEqual(len(center_card["attached_cheer"]), 0)
+
+        # Events
+        actions = reset_mainstep(self)
+        self.assertIsNone(
+        next((action for action in actions if action["action_type"] == GameAction.MainStepBatonPass and action["center_id"] == center_card_id), None))
+
+        # with sufficient cheers
+        spawn_cheer_on_card(self, p1, center_card_id, "white", "w1") # any color
+        actions = reset_mainstep(self)
+        self.assertIsNotNone(
+        next((action for action in actions if action["action_type"] == GameAction.MainStepBatonPass and action["center_id"] == center_card_id), None))
+
+    def test_hbp02_020_downed_health(self):
+        engine = self.engine
+    
+        p1: PlayerState = engine.get_player(self.player1)
+        p2: PlayerState = engine.get_player(self.player2)
+        
+        # Setup to have player2 have card damaged in the center
+        p2.center = []
+        p2_center_card, p2_center_card_id = unpack_game_id(put_card_in_play(self, p2, "hBP02-020", p2.center))
+        p2_center_card["damage"] = p2_center_card["hp"] - 10
+
+        _, center_card_id = unpack_game_id(p1.center[0])
+
+        """Test"""
+        self.assertEqual(engine.active_player_id, self.player1)
+
+        begin_performance(self)
+        engine.handle_game_message(self.player1, GameAction.PerformanceStepUseArt, {
+        "art_id": "nunnun",
+        "performer_id": center_card_id,
+        "target_id": p2_center_card_id
+        })
+
+        # Events
+        events = engine.grab_events()
+        validate_consecutive_events(self, self.player1, events, [
+        (EventType.EventType_PerformArt, {}),
+        (EventType.EventType_DamageDealt, {}),
+        (EventType.EventType_DownedHolomem_Before, {}),
+        (EventType.EventType_DownedHolomem, { "life_lost": 1, "target_id": p2_center_card_id }),
+        (EventType.EventType_Decision_SendCheer, {})
+        ])

--- a/tests/hBP02/test_hbp02_021.py
+++ b/tests/hBP02/test_hbp02_021.py
@@ -1,0 +1,237 @@
+import unittest
+from app.gameengine import GameEngine, GameAction
+from app.gameengine import PlayerState
+from app.gameengine import EventType
+from tests.helpers import *
+
+class Test_hBP02_021(unittest.TestCase):
+    engine: GameEngine
+    player1: str
+    player2: str
+
+    def setUp(self):
+        p1_deck = generate_deck_with("", {
+            "hBP02-021": 3,
+        })
+        p2_deck = generate_deck_with("", {
+            "hBP02-021": 3,
+        })
+        initialize_game_to_third_turn(self, p1_deck, p2_deck)
+
+    def test_hbp02_021_overall_check(self):
+        p1: PlayerState = self.engine.get_player(self.player1)
+        card = next((card for card in p1.deck if card["card_id"] == "hBP02-021"), None)
+        self.assertIsNotNone(card)
+
+        # check hp and tags
+        self.assertEqual(card["hp"], 120)
+        self.assertCountEqual(card["tags"], ["#ID", "#IDGen2", "#Bird", "#Art"])
+
+    def test_hbp02_021_dakaramiteteneutatteodorimasu(self):
+        engine = self.engine
+    
+        p1: PlayerState = engine.get_player(self.player1)
+        p2: PlayerState = engine.get_player(self.player2)
+
+        # Setup Reine in the center
+        p1.center = []
+        _, center_card_id = unpack_game_id(put_card_in_play(self, p1, "hBP02-021", p1.center))
+        spawn_cheer_on_card(self, p1, center_card_id, "red", "r1") # any color
+        valid_target_ids = ids_from_cards(p1.get_holomem_on_stage())
+
+        # Add multiple cheers to archive (5 cheers, 5 non-cheers)
+        cheer_cards = p1.cheer_deck[:5]
+        _, cheer_card_id = unpack_game_id(cheer_cards[0])
+        p1.archive = p1.deck[:5] + cheer_cards
+        p1.cheer_deck = p1.cheer_deck[5:]
+        p1.deck = p1.deck[:5]
+
+        """Test"""
+        self.assertEqual(engine.active_player_id, self.player1)
+
+        begin_performance(self)
+        engine.handle_game_message(self.player1, GameAction.PerformanceStepUseArt, {
+            "art_id": "dakaramiteteneutatteodorimasu",
+            "performer_id": center_card_id,
+            "target_id": p2.center[0]["game_card_id"]
+        })
+        engine.handle_game_message(self.player1, GameAction.EffectResolution_MoveCheerBetweenHolomems, {
+            "placements": { cheer_card_id: center_card_id }
+        })
+
+        # Events
+        events = engine.grab_events()
+        validate_consecutive_events(self, self.player1, events, [
+            (EventType.EventType_PerformArt, { "art_id": "dakaramiteteneutatteodorimasu", "power": 20 }),
+            (EventType.EventType_Decision_SendCheer, { "from_options": ids_from_cards(cheer_cards), "to_options": valid_target_ids }),
+            (EventType.EventType_MoveAttachedCard, { "from_holomem_id": "archive", "to_holomem_id": center_card_id, "attached_id": cheer_card_id }),
+            (EventType.EventType_DamageDealt, { "damage": 20 }),
+            *end_turn_events()
+        ])
+
+    def test_hbp02_021_dakaramiteteneutatteodorimasu_no_cheer_in_archive(self):
+        engine = self.engine
+    
+        p1: PlayerState = engine.get_player(self.player1)
+        p2: PlayerState = engine.get_player(self.player2)
+
+        # Setup Reine in the center
+        p1.center = []
+        _, center_card_id = unpack_game_id(put_card_in_play(self, p1, "hBP02-021", p1.center))
+        spawn_cheer_on_card(self, p1, center_card_id, "red", "r1") # any color
+
+        p1.archive = []
+
+        """Test"""
+        self.assertEqual(engine.active_player_id, self.player1)
+
+        begin_performance(self)
+        engine.handle_game_message(self.player1, GameAction.PerformanceStepUseArt, {
+            "art_id": "dakaramiteteneutatteodorimasu",
+            "performer_id": center_card_id,
+            "target_id": p2.center[0]["game_card_id"]
+        })
+
+        # Events
+        events = engine.grab_events()
+        validate_consecutive_events(self, self.player1, events, [
+            (EventType.EventType_PerformArt, { "art_id": "dakaramiteteneutatteodorimasu", "power": 20 }),
+            (EventType.EventType_DamageDealt, { "damage": 20 }),
+            *end_turn_events()
+        ])
+
+    def test_hbp02_021_baton_pass(self):
+        engine = self.engine
+    
+        p1: PlayerState = engine.get_player(self.player1)
+
+        # Setup to have card in the center
+        p1.center = []
+        center_card, center_card_id = unpack_game_id(put_card_in_play(self, p1, "hBP02-021", p1.center))
+
+        """Test"""
+        self.assertEqual(engine.active_player_id, self.player1)
+
+        # no cheers to use baton pass
+        self.assertEqual(len(center_card["attached_cheer"]), 0)
+
+        # Events
+        actions = reset_mainstep(self)
+        self.assertIsNone(
+        next((action for action in actions if action["action_type"] == GameAction.MainStepBatonPass and action["center_id"] == center_card_id), None))
+
+        # with sufficient cheers
+        spawn_cheer_on_card(self, p1, center_card_id, "white", "w1") # any color
+        actions = reset_mainstep(self)
+        self.assertIsNotNone(
+        next((action for action in actions if action["action_type"] == GameAction.MainStepBatonPass and action["center_id"] == center_card_id), None))
+
+    def test_hbp02_021_downed_health(self):
+        engine = self.engine
+    
+        p1: PlayerState = engine.get_player(self.player1)
+        p2: PlayerState = engine.get_player(self.player2)
+        
+        # Setup to have player2 have card damaged in the center
+        p2.center = []
+        p2_center_card, p2_center_card_id = unpack_game_id(put_card_in_play(self, p2, "hBP02-021", p2.center))
+        p2_center_card["damage"] = p2_center_card["hp"] - 10
+
+        _, center_card_id = unpack_game_id(p1.center[0])
+
+        """Test"""
+        self.assertEqual(engine.active_player_id, self.player1)
+
+        begin_performance(self)
+        engine.handle_game_message(self.player1, GameAction.PerformanceStepUseArt, {
+        "art_id": "nunnun",
+        "performer_id": center_card_id,
+        "target_id": p2_center_card_id
+        })
+
+        # Events
+        events = engine.grab_events()
+        validate_consecutive_events(self, self.player1, events, [
+        (EventType.EventType_PerformArt, {}),
+        (EventType.EventType_DamageDealt, {}),
+        (EventType.EventType_DownedHolomem_Before, {}),
+        (EventType.EventType_DownedHolomem, { "life_lost": 1, "target_id": p2_center_card_id }),
+        (EventType.EventType_Decision_SendCheer, {})
+        ])
+
+    def test_hbp02_021_bloom_effect(self):
+        engine = self.engine
+    
+        p1: PlayerState = engine.get_player(self.player1)
+        
+        # Setup to have 1st reine in the center and 1st reine in hand
+        p1.center = []
+        p1.backstage = []
+        _, bloom_card_id = unpack_game_id(add_card_to_hand(self, p1, "hBP02-021"))
+        _, center_card_id = unpack_game_id(put_card_in_play(self, p1, "hBP02-021", p1.center))
+        spawn_cheer_on_card(self, p1, center_card_id, "white", "w1") # any color
+        spawn_cheer_on_card(self, p1, center_card_id, "green", "g1") # any color
+        spawn_cheer_on_card(self, p1, center_card_id, "blue", "b1") # any color
+        spawn_cheer_on_card(self, p1, center_card_id, "red", "r1") # any color        
+        backstage_card, backstage_card_id = unpack_game_id(put_card_in_play(self, p1, "hBP02-021", p1.backstage))
+        spawn_cheer_on_card(self, p1, backstage_card_id, "green", "g2") # any color
+        spawn_cheer_on_card(self, p1, backstage_card_id, "purple", "p1") # any color
+
+        backstage_card["damage"] = 60       
+
+        
+
+        """Test"""
+        self.assertEqual(engine.active_player_id, self.player1)
+
+        engine.handle_game_message(self.player1, GameAction.MainStepBloom, { "card_id": bloom_card_id, "target_id": center_card_id })
+
+        valid_target_ids = ids_from_cards(p1.get_holomem_on_stage())
+
+        engine.handle_game_message(self.player1, GameAction.EffectResolution_MakeChoice, { "choice_index": 0 })
+        engine.handle_game_message(self.player1, GameAction.EffectResolution_ChooseCardsForEffect, { "card_ids": [backstage_card_id] })
+
+        # Events
+        events = engine.grab_events()
+        validate_consecutive_events(self, self.player1, events, [
+        (EventType.EventType_Bloom, { "bloom_card_id": bloom_card_id }),
+        (EventType.EventType_Decision_Choice, {}),
+        (EventType.EventType_Decision_ChooseHolomemForEffect, { "cards_can_choose": valid_target_ids }),
+        (EventType.EventType_RestoreHP, { "healed_amount": 50, "new_damage": 10  }),
+        (EventType.EventType_Decision_MainStep, {})
+        ])
+
+    def test_hbp02_021_bloom_effect_no_cheer(self):
+        engine = self.engine
+    
+        p1: PlayerState = engine.get_player(self.player1)
+        
+        # Setup to have 1st reine in the center and 1st reine in hand
+        p1.center = []
+        p1.backstage = []
+        _, bloom_card_id = unpack_game_id(add_card_to_hand(self, p1, "hBP02-021"))
+        _, center_card_id = unpack_game_id(put_card_in_play(self, p1, "hBP02-021", p1.center))
+        backstage_card, backstage_card_id = unpack_game_id(put_card_in_play(self, p1, "hBP02-021", p1.backstage))
+
+        backstage_card["damage"] = 60       
+
+        
+
+        """Test"""
+        self.assertEqual(engine.active_player_id, self.player1)
+
+        engine.handle_game_message(self.player1, GameAction.MainStepBloom, { "card_id": bloom_card_id, "target_id": center_card_id })
+
+        valid_target_ids = ids_from_cards(p1.get_holomem_on_stage())
+
+        engine.handle_game_message(self.player1, GameAction.EffectResolution_MakeChoice, { "choice_index": 0 })
+        engine.handle_game_message(self.player1, GameAction.EffectResolution_ChooseCardsForEffect, { "card_ids": [backstage_card_id] })
+
+        # Events
+        events = engine.grab_events()
+        validate_consecutive_events(self, self.player1, events, [
+        (EventType.EventType_Bloom, { "bloom_card_id": bloom_card_id }),
+        (EventType.EventType_Decision_Choice, {}),
+        (EventType.EventType_Decision_ChooseHolomemForEffect, { "cards_can_choose": valid_target_ids }),
+        (EventType.EventType_Decision_MainStep, {})
+        ])

--- a/tests/hBP02/test_hbp02_022.py
+++ b/tests/hBP02/test_hbp02_022.py
@@ -1,0 +1,224 @@
+import unittest
+from app.gameengine import GameEngine, GameAction
+from app.gameengine import PlayerState
+from app.gameengine import EventType
+from tests.helpers import *
+
+class Test_hBP02_022(unittest.TestCase):
+    engine: GameEngine
+    player1: str
+    player2: str
+
+    def setUp(self):
+        p1_deck = generate_deck_with("", {
+            "hBP02-022": 3,
+            "hBP02-094": 3,
+        })
+        p2_deck = generate_deck_with("", {
+            "hBP02-022": 3,
+        })
+        initialize_game_to_third_turn(self, p1_deck, p2_deck)
+
+    def test_hbp02_022_overall_check(self):
+        p1: PlayerState = self.engine.get_player(self.player1)
+        card = next((card for card in p1.deck if card["card_id"] == "hBP02-022"), None)
+        self.assertIsNotNone(card)
+
+        # check hp and tags
+        self.assertEqual(card["hp"], 130)
+        self.assertCountEqual(card["tags"], ["#ID", "#IDGen2", "#Bird", "#Art"])
+
+    def test_hbp02_022_spicynight(self):
+        engine = self.engine
+    
+        p1: PlayerState = engine.get_player(self.player1)
+        p2: PlayerState = engine.get_player(self.player2)
+        
+        # Setup to have 1st reine in the center and 1st reine in the backstage
+        p1.center = []
+        p1.backstage = []
+        _, center_card_id = unpack_game_id(put_card_in_play(self, p1, "hBP02-022", p1.center))
+        spawn_cheer_on_card(self, p1, center_card_id, "green", "g1") # any color
+        spawn_cheer_on_card(self, p1, center_card_id, "green", "g2") # any color
+        _, backstage_card_id = unpack_game_id(put_card_in_play(self, p1, "hBP02-022", p1.backstage))
+        spawn_cheer_on_card(self, p1, backstage_card_id, "green", "g3") # any color
+        spawn_cheer_on_card(self, p1, backstage_card_id, "purple", "p1") # any color
+
+        # give p2 center high hp
+        p2.center[0]["hp"] = 200
+
+        
+
+        """Test"""
+        self.assertEqual(engine.active_player_id, self.player1)
+
+        begin_performance(self)
+        engine.handle_game_message(self.player1, GameAction.PerformanceStepUseArt, {
+            "art_id": "spicynight",
+            "performer_id": center_card_id,
+            "target_id": p2.center[0]["game_card_id"]
+        })
+
+        # Events
+        events = engine.grab_events()
+        validate_consecutive_events(self, self.player1, events, [
+            (EventType.EventType_PerformArt, { "art_id": "spicynight", "power": 40 }),
+            (EventType.EventType_BoostStat, { 
+                "stat": "power",
+                "amount": 20 }),
+            (EventType.EventType_DamageDealt, { "damage": 60 }),
+            *end_turn_events()
+        ])
+
+    def test_hbp02_022_spicynight_not_enough_cheer(self):
+        engine = self.engine
+    
+        p1: PlayerState = engine.get_player(self.player1)
+        p2: PlayerState = engine.get_player(self.player2)
+        
+        # Setup to have 1st reine in the center and 1st reine in the backstage
+        p1.center = []
+        p1.backstage = []
+        _, center_card_id = unpack_game_id(put_card_in_play(self, p1, "hBP02-022", p1.center))
+        spawn_cheer_on_card(self, p1, center_card_id, "green", "g1") # any color
+        spawn_cheer_on_card(self, p1, center_card_id, "green", "g2") # any color
+        _, backstage_card_id = unpack_game_id(put_card_in_play(self, p1, "hBP02-022", p1.backstage))
+        spawn_cheer_on_card(self, p1, backstage_card_id, "green", "g3") # any color
+
+        # give p2 center high hp
+        p2.center[0]["hp"] = 200
+
+        
+
+        """Test"""
+        self.assertEqual(engine.active_player_id, self.player1)
+
+        begin_performance(self)
+        engine.handle_game_message(self.player1, GameAction.PerformanceStepUseArt, {
+            "art_id": "spicynight",
+            "performer_id": center_card_id,
+            "target_id": p2.center[0]["game_card_id"]
+        })
+
+        # Events
+        events = engine.grab_events()
+        validate_consecutive_events(self, self.player1, events, [
+            (EventType.EventType_PerformArt, { "art_id": "spicynight", "power": 40 }),
+            (EventType.EventType_DamageDealt, { "damage": 40 }),
+            *end_turn_events()
+        ])
+
+    def test_hbp02_022_baton_pass(self):
+        engine = self.engine
+    
+        p1: PlayerState = engine.get_player(self.player1)
+
+        # Setup to have card in the center
+        p1.center = []
+        center_card, center_card_id = unpack_game_id(put_card_in_play(self, p1, "hBP02-022", p1.center))
+
+        """Test"""
+        self.assertEqual(engine.active_player_id, self.player1)
+
+        # no cheers to use baton pass
+        self.assertEqual(len(center_card["attached_cheer"]), 0)
+
+        # Events
+        actions = reset_mainstep(self)
+        self.assertIsNone(
+        next((action for action in actions if action["action_type"] == GameAction.MainStepBatonPass and action["center_id"] == center_card_id), None))
+
+        # with sufficient cheers
+        spawn_cheer_on_card(self, p1, center_card_id, "white", "w1") # any color
+        actions = reset_mainstep(self)
+        self.assertIsNotNone(
+        next((action for action in actions if action["action_type"] == GameAction.MainStepBatonPass and action["center_id"] == center_card_id), None))
+
+    def test_hbp02_022_downed_health(self):
+        engine = self.engine
+    
+        p1: PlayerState = engine.get_player(self.player1)
+        p2: PlayerState = engine.get_player(self.player2)
+        
+        # Setup to have player2 have card damaged in the center
+        p2.center = []
+        p2_center_card, p2_center_card_id = unpack_game_id(put_card_in_play(self, p2, "hBP02-022", p2.center))
+        p2_center_card["damage"] = p2_center_card["hp"] - 10
+
+        _, center_card_id = unpack_game_id(p1.center[0])
+
+        """Test"""
+        self.assertEqual(engine.active_player_id, self.player1)
+
+        begin_performance(self)
+        engine.handle_game_message(self.player1, GameAction.PerformanceStepUseArt, {
+        "art_id": "nunnun",
+        "performer_id": center_card_id,
+        "target_id": p2_center_card_id
+        })
+
+        # Events
+        events = engine.grab_events()
+        validate_consecutive_events(self, self.player1, events, [
+        (EventType.EventType_PerformArt, {}),
+        (EventType.EventType_DamageDealt, {}),
+        (EventType.EventType_DownedHolomem_Before, {}),
+        (EventType.EventType_DownedHolomem, { "life_lost": 1, "target_id": p2_center_card_id }),
+        (EventType.EventType_Decision_SendCheer, {})
+        ])
+
+    def test_hbp02_022_bloom_effect_search_tantan(self):
+        engine = self.engine
+    
+        p1: PlayerState = engine.get_player(self.player1)
+        
+        # Setup to have debut Noel in the center and 1st Noel in hand
+        p1.center = []
+        _, center_card_id = unpack_game_id(put_card_in_play(self, p1, "hBP02-022", p1.center))
+        _, bloom_card_id = unpack_game_id(add_card_to_hand(self, p1, "hBP02-022"))
+
+        tantan_cards_id = ids_from_cards(p1.deck[-3:])
+        chosen_card_id = tantan_cards_id[-1]
+
+        """Test"""
+        self.assertEqual(engine.active_player_id, self.player1)
+
+        engine.handle_game_message(self.player1, GameAction.MainStepBloom, { "card_id": bloom_card_id, "target_id": center_card_id })
+        engine.handle_game_message(self.player1, GameAction.EffectResolution_ChooseCardsForEffect, { "card_ids": [chosen_card_id] })
+
+        # Events
+        events = engine.grab_events()
+        validate_consecutive_events(self, self.player1, events, [
+        (EventType.EventType_Bloom, { "bloom_card_id": bloom_card_id }),
+        (EventType.EventType_Decision_ChooseCards, { "cards_can_choose": tantan_cards_id }),
+        (EventType.EventType_MoveCard, { "from_zone": "deck", "to_zone": "hand", "card_id": chosen_card_id }),
+        (EventType.EventType_ShuffleDeck, {}),
+        (EventType.EventType_Decision_MainStep, {})
+        ])
+
+    def test_hbp02_022_bloom_effect_no_tantan(self):
+        engine = self.engine
+    
+        p1: PlayerState = engine.get_player(self.player1)
+        
+        # Setup to have debut Noel in the center and 1st Noel in hand
+        p1.center = []
+        _, center_card_id = unpack_game_id(put_card_in_play(self, p1, "hBP02-022", p1.center))
+        _, bloom_card_id = unpack_game_id(add_card_to_hand(self, p1, "hBP02-022"))
+
+        p1.deck = p1.deck[:-3]
+
+        """Test"""
+        self.assertEqual(engine.active_player_id, self.player1)
+
+        engine.handle_game_message(self.player1, GameAction.MainStepBloom, { "card_id": bloom_card_id, "target_id": center_card_id })
+        engine.handle_game_message(self.player1, GameAction.EffectResolution_ChooseCardsForEffect, { "card_ids": [] })
+
+        # Events
+        events = engine.grab_events()
+        validate_consecutive_events(self, self.player1, events, [
+        (EventType.EventType_Bloom, { "bloom_card_id": bloom_card_id }),
+        (EventType.EventType_Decision_ChooseCards, { "cards_can_choose": [] }),
+        (EventType.EventType_ShuffleDeck, {}),
+        (EventType.EventType_Decision_MainStep, {})
+        ])

--- a/tests/hBP02/test_hbp02_023.py
+++ b/tests/hBP02/test_hbp02_023.py
@@ -1,0 +1,227 @@
+import unittest
+from app.gameengine import GameEngine, GameAction
+from app.gameengine import PlayerState
+from app.gameengine import EventType
+from tests.helpers import *
+
+class Test_hBP02_023(unittest.TestCase):
+    engine: GameEngine
+    player1: str
+    player2: str
+
+    def setUp(self):
+        p1_deck = generate_deck_with("", {
+            "hBP02-023": 3,
+        })
+        p2_deck = generate_deck_with("", {
+            "hBP02-023": 3,
+        })
+        initialize_game_to_third_turn(self, p1_deck, p2_deck)
+
+    def test_hbp02_023_overall_check(self):
+        p1: PlayerState = self.engine.get_player(self.player1)
+        card = next((card for card in p1.deck if card["card_id"] == "hBP02-023"), None)
+        self.assertIsNotNone(card)
+
+        # check hp and tags
+        self.assertEqual(card["hp"], 190)
+        self.assertCountEqual(card["tags"], ["#ID", "#IDGen2", "#Bird", "#Art"])
+
+    def test_hbp02_023_kujakunodansu(self):
+        engine = self.engine
+    
+        p1: PlayerState = engine.get_player(self.player1)
+        p2: PlayerState = engine.get_player(self.player2)
+        
+        # Setup to have 2nd reine in the center and 2nd reine in the backstage
+        p1.center = []
+        p1.backstage = []
+        _, center_card_id = unpack_game_id(put_card_in_play(self, p1, "hBP02-023", p1.center))
+        spawn_cheer_on_card(self, p1, center_card_id, "green", "g1") # any color
+        spawn_cheer_on_card(self, p1, center_card_id, "green", "g2") # any color
+        spawn_cheer_on_card(self, p1, center_card_id, "green", "g3") # any color
+        spawn_cheer_on_card(self, p1, center_card_id, "green", "g4") # any color
+        spawn_cheer_on_card(self, p1, center_card_id, "red", "r1") # any color
+        _, backstage_card_id = unpack_game_id(put_card_in_play(self, p1, "hBP02-023", p1.backstage))
+        spawn_cheer_on_card(self, p1, backstage_card_id, "green", "g5") # any color
+        spawn_cheer_on_card(self, p1, backstage_card_id, "purple", "p1") # any color
+        spawn_cheer_on_card(self, p1, backstage_card_id, "blue", "b1") # any color
+        spawn_cheer_on_card(self, p1, backstage_card_id, "white", "w1") # any color
+
+        # give p2 center high hp
+        p2.center[0]["hp"] = 300
+
+        
+
+        """Test"""
+        self.assertEqual(engine.active_player_id, self.player1)
+
+        begin_performance(self)
+        engine.handle_game_message(self.player1, GameAction.PerformanceStepUseArt, {
+            "art_id": "kujakunodansu",
+            "performer_id": center_card_id,
+            "target_id": p2.center[0]["game_card_id"]
+        })
+
+        # Events
+        events = engine.grab_events()
+        validate_consecutive_events(self, self.player1, events, [
+            (EventType.EventType_PerformArt, { "art_id": "kujakunodansu", "power": 100 }),
+            (EventType.EventType_BoostStat, { 
+                "stat": "power",
+                "amount": 50 }),
+            (EventType.EventType_BoostStat, { 
+                "stat": "power",
+                "amount": 100 }),
+            (EventType.EventType_DamageDealt, { "damage": 250 }),
+            *end_turn_events()
+        ])
+
+    def test_hbp02_023_kujakunodansu_one_cheer(self):
+        engine = self.engine
+    
+        p1: PlayerState = engine.get_player(self.player1)
+        p2: PlayerState = engine.get_player(self.player2)
+        
+        # Setup to have 2nd reine in the center
+        p1.center = []
+        p1.backstage = []
+        _, center_card_id = unpack_game_id(put_card_in_play(self, p1, "hBP02-023", p1.center))
+        spawn_cheer_on_card(self, p1, center_card_id, "green", "g1") # any color
+        spawn_cheer_on_card(self, p1, center_card_id, "green", "g2") # any color
+        spawn_cheer_on_card(self, p1, center_card_id, "green", "g3") # any color
+        spawn_cheer_on_card(self, p1, center_card_id, "green", "g4") # any color
+
+        # give p2 center high hp
+        p2.center[0]["hp"] = 300
+
+        
+
+        """Test"""
+        self.assertEqual(engine.active_player_id, self.player1)
+
+        begin_performance(self)
+        engine.handle_game_message(self.player1, GameAction.PerformanceStepUseArt, {
+            "art_id": "kujakunodansu",
+            "performer_id": center_card_id,
+            "target_id": p2.center[0]["game_card_id"]
+        })
+
+        # Events
+        events = engine.grab_events()
+        validate_consecutive_events(self, self.player1, events, [
+            (EventType.EventType_PerformArt, { "art_id": "kujakunodansu", "power": 100 }),
+            (EventType.EventType_BoostStat, { 
+                "stat": "power",
+                "amount": 50 }),
+            (EventType.EventType_BoostStat, { 
+                "stat": "power",
+                "amount": 20 }),
+            (EventType.EventType_DamageDealt, { "damage": 170 }),
+            *end_turn_events()
+        ])
+
+    def test_hbp02_023_baton_pass(self):
+        engine = self.engine
+    
+        p1: PlayerState = engine.get_player(self.player1)
+
+        # Setup to have card in the center
+        p1.center = []
+        center_card, center_card_id = unpack_game_id(put_card_in_play(self, p1, "hBP02-023", p1.center))
+
+        """Test"""
+        self.assertEqual(engine.active_player_id, self.player1)
+
+        # no cheers to use baton pass
+        self.assertEqual(len(center_card["attached_cheer"]), 0)
+
+        # Events
+        actions = reset_mainstep(self)
+        self.assertIsNone(
+        next((action for action in actions if action["action_type"] == GameAction.MainStepBatonPass and action["center_id"] == center_card_id), None))
+
+        # with sufficient cheers
+        spawn_cheer_on_card(self, p1, center_card_id, "white", "w1") # any color
+        spawn_cheer_on_card(self, p1, center_card_id, "white", "w1") # any color
+        actions = reset_mainstep(self)
+        self.assertIsNotNone(
+        next((action for action in actions if action["action_type"] == GameAction.MainStepBatonPass and action["center_id"] == center_card_id), None))
+
+    def test_hbp02_023_downed_health(self):
+        engine = self.engine
+    
+        p1: PlayerState = engine.get_player(self.player1)
+        p2: PlayerState = engine.get_player(self.player2)
+        
+        # Setup to have player2 have card damaged in the center
+        p2.center = []
+        p2_center_card, p2_center_card_id = unpack_game_id(put_card_in_play(self, p2, "hBP02-023", p2.center))
+        p2_center_card["damage"] = p2_center_card["hp"] - 10
+
+        _, center_card_id = unpack_game_id(p1.center[0])
+
+        """Test"""
+        self.assertEqual(engine.active_player_id, self.player1)
+
+        begin_performance(self)
+        engine.handle_game_message(self.player1, GameAction.PerformanceStepUseArt, {
+        "art_id": "nunnun",
+        "performer_id": center_card_id,
+        "target_id": p2_center_card_id
+        })
+
+        # Events
+        events = engine.grab_events()
+        validate_consecutive_events(self, self.player1, events, [
+        (EventType.EventType_PerformArt, {}),
+        (EventType.EventType_DamageDealt, {}),
+        (EventType.EventType_DownedHolomem_Before, {}),
+        (EventType.EventType_DownedHolomem, { "life_lost": 1, "target_id": p2_center_card_id }),
+        (EventType.EventType_Decision_SendCheer, {})
+        ])
+
+    def test_hbp02_023_bloom_effect(self):
+        engine = self.engine
+    
+        p1: PlayerState = engine.get_player(self.player1)
+        
+        # Setup to have 2nd reine in the center&backstage and 2nd reine in hand
+        p1.center = []
+        p1.backstage = []
+        _, bloom_card_id = unpack_game_id(add_card_to_hand(self, p1, "hBP02-023"))
+        _, center_card_id = unpack_game_id(put_card_in_play(self, p1, "hBP02-023", p1.center))
+        _, _ = unpack_game_id(put_card_in_play(self, p1, "hBP02-023", p1.backstage))
+        
+
+        topcheer = p1.cheer_deck[0]["game_card_id"]
+
+        """Test"""
+        self.assertEqual(engine.active_player_id, self.player1)
+
+        engine.handle_game_message(self.player1, GameAction.MainStepBloom, { "card_id": bloom_card_id, "target_id": center_card_id })
+
+        valid_target_ids = ids_from_cards(p1.get_holomem_on_stage())
+
+        engine.handle_game_message(self.player1, GameAction.EffectResolution_MoveCheerBetweenHolomems, {
+            "placements": {topcheer: bloom_card_id}
+        })
+        
+
+        # Events
+        events = engine.grab_events()
+        validate_consecutive_events(self, self.player1, events, [
+        (EventType.EventType_Bloom, { "bloom_card_id": bloom_card_id }),
+        (EventType.EventType_Decision_SendCheer, { 
+            "effect_player_id": self.player1,
+            "amount_min": 1,
+            "amount_max": 1,
+            "from_zone": "cheer_deck",
+            "to_zone": "holomem",
+            "to_options": valid_target_ids }),
+        (EventType.EventType_MoveAttachedCard, { 
+            "from_holomem_id": "cheer_deck", 
+            "to_holomem_id": bloom_card_id, 
+            "attached_id": topcheer }),
+        (EventType.EventType_Decision_MainStep, {})
+        ])

--- a/tests/hBP02/test_hbp02_079.py
+++ b/tests/hBP02/test_hbp02_079.py
@@ -1,0 +1,103 @@
+import unittest
+from app.gameengine import GameEngine, GameAction
+from app.gameengine import PlayerState
+from app.gameengine import EventType
+from tests.helpers import *
+
+class Test_hBP02_079(unittest.TestCase):
+    engine: GameEngine
+    player1: str
+    player2: str
+
+    def setUp(self):
+        p1_deck = generate_deck_with("", {
+            "hBP02-020": 1,
+            "hBP02-079": 3,
+        })
+        p2_deck = generate_deck_with("", {
+            "hBP02-020": 2,
+            "hBP02-079": 3,
+        })
+        initialize_game_to_third_turn(self, p1_deck, p2_deck)
+
+    def test_hbp02_079_activate_magic_prevent_life_loss(self):
+        engine = self.engine
+    
+        p1: PlayerState = engine.get_player(self.player1)
+        p2: PlayerState = engine.get_player(self.player2)
+
+        # Setup add bakuhatsunomahou to hand
+        p1.center = []
+        _, support_card_id = unpack_game_id(add_card_to_hand(self, p1, "hBP02-079"))
+        _, _ = unpack_game_id(put_card_in_play(self, p1, "hBP02-020", p1.center))
+
+        # give p2 center low hp
+        p2.center = []
+        p2.collab = []
+        opponent_center_card, opponent_center_card_id = unpack_game_id(put_card_in_play(self, p2, "hBP02-020", p2.center))
+        _, _ = unpack_game_id(put_card_in_play(self, p2, "hBP02-020", p2.collab))
+        opponent_center_card["damage"] = opponent_center_card["hp"] - 10
+
+        """Test"""
+        self.assertEqual(engine.active_player_id, self.player1)
+        engine.handle_game_message(self.player1, GameAction.MainStepPlaySupport, { "card_id": support_card_id })
+        engine.handle_game_message(self.player1, GameAction.EffectResolution_ChooseCardsForEffect, { "card_ids": [opponent_center_card_id] })
+        
+
+        # Events
+        events = engine.grab_events()
+        validate_consecutive_events(self, self.player1, events, [
+            (EventType.EventType_PlaySupportCard, { "card_id": support_card_id }),
+            (EventType.EventType_Decision_ChooseHolomemForEffect, {"effect_player_id": self.player1}),
+            (EventType.EventType_DamageDealt, { "damage": 20 }),
+            (EventType.EventType_DownedHolomem_Before, {}),
+            (EventType.EventType_DownedHolomem, {
+                "game_over": False,
+                "target_player": self.player2,
+                "life_lost": 0,
+                "life_loss_prevented": True,
+            }),
+            (EventType.EventType_MoveCard, {}),
+            (EventType.EventType_Decision_MainStep, {}),
+        ])
+
+    def test_hbp02_079_activated_magic_tag_cannot_activate_magic_again(self):
+        engine = self.engine
+    
+        p1: PlayerState = engine.get_player(self.player1)
+        p2: PlayerState = engine.get_player(self.player2)
+
+        # Setup add bakuhatsunomahou to hand
+        p1.center = []
+        _, support_card_id = unpack_game_id(add_card_to_hand(self, p1, "hBP02-079"))
+        add_card_to_hand(self, p1, "hBP02-079")
+        _, _ = unpack_game_id(put_card_in_play(self, p1, "hBP02-020", p1.center))
+
+        # give p2 center high hp
+        p2.center[0]["hp"] = 100
+
+        """Test"""
+        self.assertEqual(engine.active_player_id, self.player1)
+        engine.handle_game_message(self.player1, GameAction.MainStepPlaySupport, { "card_id": support_card_id })
+        
+
+        # Events
+        events = engine.grab_events()
+        validate_consecutive_events(self, self.player1, events, [
+            (EventType.EventType_PlaySupportCard, { "card_id": support_card_id }),
+            (EventType.EventType_DamageDealt, { "damage": 20 }),
+            (EventType.EventType_MoveCard, {}),
+            (EventType.EventType_Decision_MainStep, {}),
+        ])
+
+        # Check that there is no action to play support because we already played a magic.
+        actions = reset_mainstep(self)
+        self.assertTrue(GameAction.MainStepPlaySupport not in [action["action_type"] for action in actions])
+
+        # End turn twice and we can play again.
+        end_turn(self)
+        do_cheer_step_on_card(self, p2.center[0])
+        end_turn(self)
+        do_cheer_step_on_card(self, p1.center[0])
+        actions = reset_mainstep(self)
+        self.assertTrue(GameAction.MainStepPlaySupport in [action["action_type"] for action in actions])

--- a/tests/hBP02/test_hbp02_094.py
+++ b/tests/hBP02/test_hbp02_094.py
@@ -1,0 +1,175 @@
+import unittest
+from app.gameengine import GameEngine, GameAction
+from app.gameengine import PlayerState
+from app.gameengine import EventType
+from tests.helpers import *
+
+class Test_hBP02_094(unittest.TestCase):
+    engine: GameEngine
+    player1: str
+    player2: str
+
+    def setUp(self):
+        p1_deck = generate_deck_with("", {
+            "hBP02-020": 1, # reine
+            "hBP01-053": 1, # iofifteen
+            "hBP02-094": 3, # Tatang
+        })
+        initialize_game_to_third_turn(self, p1_deck)
+
+    def test_hbp02_094_attach_effect_reine_hp(self):
+        engine = self.engine
+    
+        p1: PlayerState = engine.get_player(self.player1)
+        p2: PlayerState = engine.get_player(self.player2)
+
+        # Setup Tatang in hand
+        _, mascot_card_id = unpack_game_id(add_card_to_hand(self, p1, "hBP02-094"))
+        center_card, center_card_id = unpack_game_id(put_card_in_play(self, p1, "hBP02-020", p1.center))
+
+        """Test"""
+        self.assertEqual(engine.active_player_id, self.player1)
+
+        # Attach to center
+        engine.handle_game_message(self.player1, GameAction.MainStepPlaySupport, { "card_id": mascot_card_id })
+        engine.handle_game_message(self.player1, GameAction.EffectResolution_ChooseCardsForEffect, { "card_ids": [ center_card_id ] })
+
+        # Events
+        events = engine.grab_events()
+        validate_consecutive_events(self, self.player1, events, [
+            (EventType.EventType_PlaySupportCard, { "card_id": mascot_card_id }),
+            (EventType.EventType_Decision_ChooseHolomemForEffect, {}),
+            (EventType.EventType_MoveCard, { "from_zone": "floating", "to_zone": "holomem", "zone_card_id": center_card_id }),
+            (EventType.EventType_Decision_MainStep, {})
+        ])
+
+        # check hp
+        self.assertEqual(center_card["hp"], 160)
+        self.assertEqual(p1.get_card_hp(center_card), 160 + 30)
+
+    def test_hbp02_094_attach_effect_other_hp(self):
+        engine = self.engine
+    
+        p1: PlayerState = engine.get_player(self.player1)
+        p2: PlayerState = engine.get_player(self.player2)
+
+        # Setup Tatang in hand
+        _, mascot_card_id = unpack_game_id(add_card_to_hand(self, p1, "hBP02-094"))
+        center_card, center_card_id = unpack_game_id(put_card_in_play(self, p1, "hBP01-053", p1.center))
+
+        """Test"""
+        self.assertEqual(engine.active_player_id, self.player1)
+
+        # Attach to center
+        engine.handle_game_message(self.player1, GameAction.MainStepPlaySupport, { "card_id": mascot_card_id })
+        engine.handle_game_message(self.player1, GameAction.EffectResolution_ChooseCardsForEffect, { "card_ids": [ center_card_id ] })
+
+        # Events
+        events = engine.grab_events()
+        validate_consecutive_events(self, self.player1, events, [
+            (EventType.EventType_PlaySupportCard, { "card_id": mascot_card_id }),
+            (EventType.EventType_Decision_ChooseHolomemForEffect, {}),
+            (EventType.EventType_MoveCard, { "from_zone": "floating", "to_zone": "holomem", "zone_card_id": center_card_id }),
+            (EventType.EventType_Decision_MainStep, {})
+        ])
+
+        # check hp
+        self.assertEqual(center_card["hp"], 170)
+        self.assertEqual(p1.get_card_hp(center_card), 170)
+
+    def test_hbp02_094_attach_effect_reine_attack(self):
+        engine = self.engine
+    
+        p1: PlayerState = engine.get_player(self.player1)
+        p2: PlayerState = engine.get_player(self.player2)
+
+        # Setup Tatang in hand
+        _, mascot_card_id = unpack_game_id(add_card_to_hand(self, p1, "hBP02-094"))
+        _, center_card_id = unpack_game_id(put_card_in_play(self, p1, "hBP02-020", p1.center))
+        spawn_cheer_on_card(self, p1, center_card_id, "green", "g1") # green color
+        spawn_cheer_on_card(self, p1, center_card_id, "red", "r1") # any color
+
+        # give p2 center high hp
+        p2.center[0]["hp"] = 200
+
+        """Test"""
+        self.assertEqual(engine.active_player_id, self.player1)
+
+        # Attach to center
+        engine.handle_game_message(self.player1, GameAction.MainStepPlaySupport, { "card_id": mascot_card_id })
+        engine.handle_game_message(self.player1, GameAction.EffectResolution_ChooseCardsForEffect, { "card_ids": [ center_card_id ] })
+
+        # Events
+        events = engine.grab_events()
+        validate_consecutive_events(self, self.player1, events, [
+            (EventType.EventType_PlaySupportCard, { "card_id": mascot_card_id }),
+            (EventType.EventType_Decision_ChooseHolomemForEffect, {}),
+            (EventType.EventType_MoveCard, { "from_zone": "floating", "to_zone": "holomem", "zone_card_id": center_card_id }),
+            (EventType.EventType_Decision_MainStep, {})
+        ])
+
+        # Attack
+        begin_performance(self)
+        engine.handle_game_message(self.player1, GameAction.PerformanceStepUseArt, {
+            "art_id": "royalhalusleepover",
+            "performer_id": center_card_id,
+            "target_id": p2.center[0]["game_card_id"]
+        })
+
+        # Events
+        events = engine.grab_events()
+        validate_consecutive_events(self, self.player1, events, [
+            (EventType.EventType_PerformArt, { "art_id": "royalhalusleepover", "power": 50 }),
+            (EventType.EventType_BoostStat, { "stat": "power", "amount": 10, }),
+            (EventType.EventType_DamageDealt, { "damage": 60 }),
+            (EventType.EventType_Decision_PerformanceStep, {}),
+        ])
+
+
+    def test_hbp02_094_attach_effect_other_attack(self):
+        engine = self.engine
+    
+        p1: PlayerState = engine.get_player(self.player1)
+        p2: PlayerState = engine.get_player(self.player2)
+
+        # Setup Tatang in hand
+        _, mascot_card_id = unpack_game_id(add_card_to_hand(self, p1, "hBP02-094"))
+        _, center_card_id = unpack_game_id(put_card_in_play(self, p1, "hBP01-053", p1.center))
+        spawn_cheer_on_card(self, p1, center_card_id, "green", "g1") # green color
+        spawn_cheer_on_card(self, p1, center_card_id, "red", "r1") # any color
+
+        # give p2 center high hp
+        p2.center[0]["hp"] = 200
+
+        """Test"""
+        self.assertEqual(engine.active_player_id, self.player1)
+
+        # Attach to center
+        engine.handle_game_message(self.player1, GameAction.MainStepPlaySupport, { "card_id": mascot_card_id })
+        engine.handle_game_message(self.player1, GameAction.EffectResolution_ChooseCardsForEffect, { "card_ids": [ center_card_id ] })
+
+        # Events
+        events = engine.grab_events()
+        validate_consecutive_events(self, self.player1, events, [
+            (EventType.EventType_PlaySupportCard, { "card_id": mascot_card_id }),
+            (EventType.EventType_Decision_ChooseHolomemForEffect, {}),
+            (EventType.EventType_MoveCard, { "from_zone": "floating", "to_zone": "holomem", "zone_card_id": center_card_id }),
+            (EventType.EventType_Decision_MainStep, {})
+        ])
+
+        # Attack
+        begin_performance(self)
+        engine.handle_game_message(self.player1, GameAction.PerformanceStepUseArt, {
+            "art_id": "yourbelovedalien",
+            "performer_id": center_card_id,
+            "target_id": p2.center[0]["game_card_id"]
+        })
+
+        # Events
+        events = engine.grab_events()
+        validate_consecutive_events(self, self.player1, events, [
+            (EventType.EventType_PerformArt, { "art_id": "yourbelovedalien", "power": 50 }),
+            (EventType.EventType_BoostStat, { "stat": "power", "amount": 10, }),
+            (EventType.EventType_DamageDealt, { "damage": 60 }),
+            (EventType.EventType_Decision_PerformanceStep, {}),
+        ])


### PR DESCRIPTION
1.holocardserver\app\gameengine.py
* Add new effect type: "power_boost_per_all_cheer_color_types"
* Add new condition:  "self_stage_has_cheer_color_types"
* Add new special restore holomem hp situation "restore_hp_per_cheer_color_types_10s"
* Add new find card property function "get_cheer_color_types_on_holomems()"
* Add new special limited type: "magic_limited"

2.holocardserver\decks\card_definitions.json
* Add new holomem "PavoliaReine" (hBP02-018~hBP02-023)
* Add new support "bakuhatsunomahou" (hBP02-079)
* Add new support mascot "tatang" (hBP02-094)

3.holocardserver\tests\hBP02\test_hbp02_018.py 
* hBP02-018 Unittest

4.holocardserver\tests\hBP02\test_hbp02_019.py 
* hBP02-019 Unittest

5.holocardserver\tests\hBP02\test_hbp02_020.py 
* hBP02-020 Unittest

6.holocardserver\tests\hBP02\test_hbp02_021.py 
* hBP02-021 Unittest

7.holocardserver\tests\hBP02\test_hbp02_022.py 
* hBP02-022 Unittest

8.holocardserver\tests\hBP02\test_hbp02_023.py 
* hBP02-023 Unittest

9.holocardserver\tests\hBP02\test_hbp02_079.py 
* hBP02-079 Unittest

10.holocardserver\tests\hBP02\test_hbp02_094.py 
* hBP02-094 Unittest
