### PR TITLE
New Oshi card Pavolia Reine hBP02-002 & Fix 2nd holomem bloom effect Pavolia Reine hBP02-023

### DIFF
--- a/app/gameengine.py
+++ b/app/gameengine.py
@@ -70,6 +70,7 @@ class EffectType:
     EffectType_PowerBoostPerAllMascots = "power_boost_per_all_mascots"
     EffectType_PowerBoostPerArchivedHolomem = "power_boost_per_archived_holomem"
     EffectType_PowerBoostPerAllCheerColorTypes = "power_boost_per_all_cheer_color_types"
+    EffectType_PowerBoostPerCheerColorTypes = "power_boost_per_cheer_color_types"
     EffectType_PowerBoostPerAttachedCheer = "power_boost_per_attached_cheer"
     EffectType_PowerBoostPerBackstage = "power_boost_per_backstage"
     EffectType_PowerBoostPerHolomem = "power_boost_per_holomem"
@@ -3913,6 +3914,23 @@ class GameEngine:
                 multiplier = len(effect_player.get_cheer_color_types_on_holomems())
                 total = per_amount * multiplier
                 self.handle_power_boost(total, effect["source_card_id"])
+            case EffectType.EffectType_PowerBoostPerCheerColorTypes:
+                per_amount = effect["amount"]
+                match effect.get("oshi_effect_target", ""):
+                    case "center":
+                        source_card = effect_player.center
+                    case "collab":
+                        source_card = effect_player.collab
+                    case _:
+                        source_card, _, _ = effect_player.find_card(effect["source_card_id"])
+                cheer_color_types = set()
+                for card in source_card:
+                    for attached_card in card["attached_cheer"]:
+                        if is_card_cheer(attached_card):
+                            cheer_color_types.update(attached_card["colors"])
+                multiplier = len(cheer_color_types)
+                total = per_amount * multiplier
+                self.handle_power_boost(total, effect["source_card_id"]) 
             case EffectType.EffectType_PowerBoostPerAttachedCheer:
                 per_amount = effect["amount"]
                 limit = effect["limit"]

--- a/decks/card_definitions.json
+++ b/decks/card_definitions.json
@@ -8193,6 +8193,91 @@
         ]
     },
     {
+        "card_id": "hBP02-002",
+        "card_type": "oshi",
+        "card_names": ["pavolia_reine"],
+        "colors": ["green"],
+        "rarity": "osr",
+        "life": 5,
+        "actions": [
+            {
+                "skill_id": "halu",
+                "cost": 2,
+                "limit": "once_per_turn",
+                "effects": [
+                    {
+                        "effect_type": "oshi_activation",
+                        "limit": "once_per_turn",
+                        "skill_id": "halu",
+                        "pre_effects": [
+                            { "effect_type": "spend_holopower", "amount": 2 },
+                            { "effect_type": "record_used_once_per_turn_effect", "effect_id": "halu" }
+                        ]
+                    },
+                    {
+                        "effect_type": "archive_cheer_from_holomem",
+                        "required_colors": ["green"],
+                        "ability_source": "oshi_green",
+                        "from": "holomem",
+                        "amount": 1
+                    }, 
+                    { 
+                        "effect_type": "choose_cards",
+                        "from": "cheer_deck",
+                        "look_at": -1,
+                        "destination": "holomem",
+                        "amount_min": 1,
+                        "amount_max": 1,
+                        "reveal_chosen": true,
+                        "remaining_cards_action": "shuffle"
+                    }
+                ]
+            },
+            {
+                "skill_id": "acolorfulfeast",
+                "cost": 2,
+                "limit": "once_per_game",
+                "effects": [
+                    {
+                        "effect_type": "oshi_activation",
+                        "limit": "once_per_game",
+                        "skill_id": "acolorfulfeast",
+                        "pre_effects": [
+                            { "effect_type": "spend_holopower", "amount": 2 },
+                            { "effect_type": "record_used_once_per_game_effect", "effect_id": "acolorfulfeast" }
+                        ]
+                    },
+                    {
+                        "effect_type": "add_turn_effect",
+                        "turn_effect": {
+                            "conditions": [
+                                { "condition": "performer_is_center" },
+                                { "condition": "performer_has_any_tag", "condition_tags": ["#IDGen2"]}
+                            ],
+                            "timing": "before_art",
+                            "effect_type": "power_boost_per_cheer_color_types",
+                            "oshi_effect_target": "center",
+                            "amount": 20
+                        }
+                    },
+                    {
+                        "effect_type": "add_turn_effect",
+                        "turn_effect": {
+                            "conditions": [
+                                { "condition": "performer_is_collab" },
+                                { "condition": "performer_has_any_tag", "condition_tags": ["#IDGen2"]}
+                            ],
+                            "timing": "before_art",
+                            "effect_type": "power_boost_per_cheer_color_types",
+                            "oshi_effect_target": "collab",
+                            "amount": 20
+                        }
+                    }
+                ]
+            }
+        ]
+    },
+    {
         "card_id": "hBP02-003",
         "card_type": "oshi",
         "card_names": ["houshou_marine"],
@@ -8903,11 +8988,14 @@
         ],
         "bloom_effects": [
             {
-                "effect_type": "send_cheer",
+                "effect_type": "choose_cards",
+                "from": "cheer_deck",
+                "look_at": -1,
+                "destination": "holomem",
                 "amount_min": 1,
                 "amount_max": 1,
-                "from": "cheer_deck",
-                "to": "holomem"
+                "reveal_chosen": true,
+                "remaining_cards_action": "shuffle"
             }
         ]
     },

--- a/tests/hBP02/test_hbp02_002.py
+++ b/tests/hBP02/test_hbp02_002.py
@@ -1,0 +1,199 @@
+import unittest
+from app.gameengine import GameEngine, GameAction, is_card_holomem
+from app.gameengine import PlayerState
+from app.gameengine import EventType
+from tests.helpers import *
+
+
+class Test_hBP02_002(unittest.TestCase):
+  engine: GameEngine
+  player1: str
+  player2: str
+
+
+  def setUp(self):
+    p1_deck = generate_deck_with("hBP02-002", {
+      "hBP02-018": 2, # debut card
+      "hBP02-023": 1, # collab card
+      "hBP02-029": 1,
+      "hBP01-053": 1, # lofi
+    })
+    initialize_game_to_third_turn(self, p1_deck)
+
+
+  def test_hbp02_002_oshi_skill_effect_halu(self):
+    engine = self.engine
+  
+    p1: PlayerState = engine.get_player(self.player1)
+    
+    p1.generate_holopower(2)
+    
+    # Setup a green holomem in the center, and set a not green holomem in the backstage
+    p1.center = []
+    p1.backstage = []
+    p1.archive = []
+    _, center_card_id = unpack_game_id(put_card_in_play(self, p1, "hBP02-018", p1.center))
+    g1 = spawn_cheer_on_card(self, p1, center_card_id, "green", "g1")
+    r1 = spawn_cheer_on_card(self, p1, center_card_id, "red", "r1")
+    _, backstage_card_id = unpack_game_id(put_card_in_play(self, p1, "hBP02-029", p1.backstage))
+    g2 = spawn_cheer_on_card(self, p1, center_card_id, "green", "g2")
+    b1 = spawn_cheer_on_card(self, p1, center_card_id, "blue", "b1")
+
+    topcheer_id = p1.cheer_deck[0]["game_card_id"]
+
+    """Test"""
+    self.assertEqual(engine.active_player_id, self.player1)
+
+    engine.handle_game_message(self.player1, GameAction.MainStepOshiSkill, { "skill_id": "halu" })
+    # archive a cheer from green holomem
+    engine.handle_game_message(self.player1, GameAction.EffectResolution_ChooseCardsForEffect, {
+        "card_ids": [g1["game_card_id"]]
+    })
+    # reveal a cheer from cheer deck and attach it to the backstage holomem
+    engine.handle_game_message(self.player1, GameAction.EffectResolution_ChooseCardsForEffect, { "card_ids": [topcheer_id] })
+    engine.handle_game_message(self.player1, GameAction.EffectResolution_ChooseCardsForEffect, { "card_ids": [backstage_card_id] })
+
+    # Events
+    events = engine.grab_events()
+    validate_consecutive_events(self, self.player1, events, [
+        (EventType.EventType_MoveCard, { "from_zone": "holopower", "to_zone": "archive" }),
+        (EventType.EventType_MoveCard, { "from_zone": "holopower", "to_zone": "archive" }),
+        (EventType.EventType_OshiSkillActivation, { "skill_id": "halu" }),
+        (EventType.EventType_Decision_ChooseCards, {
+            "from_zone": "holomem",
+            "to_zone": "archive",
+            "amount_min": 1,
+            "amount_max": 1,
+        }),
+        (EventType.EventType_MoveCard, { 
+            "moving_player_id": self.player1,
+            "from_zone": center_card_id,
+            "to_zone": "archive",
+            "card_id": g1["game_card_id"],
+        }),
+        (EventType.EventType_Decision_ChooseCards, { 
+            "from_zone": "cheer_deck",
+            "to_zone": "holomem" }),
+        (EventType.EventType_Decision_ChooseHolomemForEffect, {}),
+        (EventType.EventType_MoveCard, {
+            "moving_player_id": self.player1,
+            "from_zone": "cheer_deck",
+            "to_zone": "holomem",
+            "zone_card_id": backstage_card_id,
+            "card_id": topcheer_id,
+        }),
+        (EventType.EventType_Decision_MainStep, {})
+    ])
+
+  def test_hbp02_002_oshi_skill_effect_acolorfulfeast_is_idgen2(self):
+    engine = self.engine
+  
+    p1: PlayerState = engine.get_player(self.player1)
+    p2: PlayerState = engine.get_player(self.player2)
+    
+    p1.generate_holopower(2)
+
+    # Setup a IDGen2 holomem in the center, and set a not IDGen2 holomem in the backstage
+    p1.center = []    
+    p1.collab = []
+    p1.backstage = []
+    p1.archive = []
+    _, center_card_id = unpack_game_id(put_card_in_play(self, p1, "hBP02-018", p1.center))
+    g1 = spawn_cheer_on_card(self, p1, center_card_id, "green", "g1")
+    r1 = spawn_cheer_on_card(self, p1, center_card_id, "red", "r1")
+    r2 = spawn_cheer_on_card(self, p1, center_card_id, "red", "r2")
+    _, backstage_card_id = unpack_game_id(put_card_in_play(self, p1, "hBP02-018", p1.backstage))
+    g2 = spawn_cheer_on_card(self, p1, backstage_card_id, "green", "g2")
+    b1 = spawn_cheer_on_card(self, p1, backstage_card_id, "blue", "b1")
+
+    # give p2 center high hp
+    p2.center[0]["hp"] = 300
+
+    """Test"""
+    self.assertEqual(engine.active_player_id, self.player1)
+
+    engine.handle_game_message(self.player1, GameAction.MainStepOshiSkill, { "skill_id": "acolorfulfeast" })
+
+    # Oshi Skill Events
+    events = engine.grab_events()
+    validate_consecutive_events(self, self.player1, events, [
+        (EventType.EventType_MoveCard, { "from_zone": "holopower", "to_zone": "archive" }),
+        (EventType.EventType_MoveCard, { "from_zone": "holopower", "to_zone": "archive" }),
+        (EventType.EventType_OshiSkillActivation, { "skill_id": "acolorfulfeast" }),
+        (EventType.EventType_AddTurnEffect, { "effect_player_id": self.player1, }),
+        (EventType.EventType_AddTurnEffect, { "effect_player_id": self.player1, }),
+        (EventType.EventType_Decision_MainStep, {})
+    ])
+
+    begin_performance(self)
+    engine.handle_game_message(self.player1, GameAction.PerformanceStepUseArt, {
+        "art_id": "peruhatelian",
+        "performer_id": center_card_id,
+        "target_id": p2.center[0]["game_card_id"]
+    })
+
+    # Perfromance Events
+    events = engine.grab_events()
+    validate_consecutive_events(self, self.player1, events, [
+        (EventType.EventType_PerformArt, { "art_id": "peruhatelian", "power": 30 }),
+        (EventType.EventType_BoostStat, { 
+                "stat": "power",
+                "amount": 40 }),
+        (EventType.EventType_DamageDealt, { "damage": 70 }),
+        *end_turn_events()
+    ])
+
+  def test_hbp02_002_oshi_skill_effect_acolorfulfeast_is_not_idgen2(self):
+    engine = self.engine
+  
+    p1: PlayerState = engine.get_player(self.player1)
+    p2: PlayerState = engine.get_player(self.player2)
+    
+    p1.generate_holopower(2)
+
+    # Setup a IDGen2 holomem in the center, and set a not IDGen2 holomem in the backstage
+    p1.center = []    
+    p1.collab = []
+    p1.backstage = []
+    p1.archive = []
+    _, center_card_id = unpack_game_id(put_card_in_play(self, p1, "hBP01-053", p1.center))
+    g1 = spawn_cheer_on_card(self, p1, center_card_id, "green", "g1")
+    r1 = spawn_cheer_on_card(self, p1, center_card_id, "red", "r1")
+    r2 = spawn_cheer_on_card(self, p1, center_card_id, "red", "r2")
+    _, backstage_card_id = unpack_game_id(put_card_in_play(self, p1, "hBP02-029", p1.backstage))
+    g2 = spawn_cheer_on_card(self, p1, backstage_card_id, "green", "g2")
+    b1 = spawn_cheer_on_card(self, p1, backstage_card_id, "blue", "b1")
+
+    # give p2 center high hp
+    p2.center[0]["hp"] = 300
+
+    """Test"""
+    self.assertEqual(engine.active_player_id, self.player1)
+
+    engine.handle_game_message(self.player1, GameAction.MainStepOshiSkill, { "skill_id": "acolorfulfeast" })
+
+    # Oshi Skill Events
+    events = engine.grab_events()
+    validate_consecutive_events(self, self.player1, events, [
+        (EventType.EventType_MoveCard, { "from_zone": "holopower", "to_zone": "archive" }),
+        (EventType.EventType_MoveCard, { "from_zone": "holopower", "to_zone": "archive" }),
+        (EventType.EventType_OshiSkillActivation, { "skill_id": "acolorfulfeast" }),
+        (EventType.EventType_AddTurnEffect, { "effect_player_id": self.player1, }),
+        (EventType.EventType_AddTurnEffect, { "effect_player_id": self.player1, }),
+        (EventType.EventType_Decision_MainStep, {})
+    ])
+
+    begin_performance(self)
+    engine.handle_game_message(self.player1, GameAction.PerformanceStepUseArt, {
+        "art_id": "yourbelovedalien",
+        "performer_id": center_card_id,
+        "target_id": p2.center[0]["game_card_id"]
+    })
+
+    # Perfromance Events
+    events = engine.grab_events()
+    validate_consecutive_events(self, self.player1, events, [
+        (EventType.EventType_PerformArt, { "art_id": "yourbelovedalien", "power": 50 }),
+        (EventType.EventType_DamageDealt, { "damage": 50 }),
+        *end_turn_events()
+    ])


### PR DESCRIPTION
1.holocardserver\app\gameengine.py
* add new power booster. its for hbp02-002 special oshi effect.

2.holocardserver\decks\card_definitions.json
* add new oshi hbp02-002 Pavolia Reine
* fix holomem bloom effect from 2nd hBP02-023 Pavolia Reine

3.holocardserver\tests\hBP02\test_hbp02_023.py
* fix holomem bloom effect from 2nd hBP02-023 Pavolia Reine

4.holocardserver\tests\hBP02\test_hbp02_002.py *hbp02-002unittest